### PR TITLE
feat(dialog): contained dialogs scoped to an element

### DIFF
--- a/docs/src/demos/DialogDemo.vue
+++ b/docs/src/demos/DialogDemo.vue
@@ -53,6 +53,68 @@
       </template>
     </Dialog>
 
+    <h3>Contained dialog</h3>
+    <p class="note">
+      <code>container</code> scopes a dialog to one element instead of the viewport. The overlay
+      dims only that box, the modality applies only inside it, and the rest of this page stays live
+      — while the dialog below is open you can still scroll the page and press the buttons above it.
+      Inside the pane, everything but the dialog is <code>inert</code>: not clickable, skipped by
+      Tab, hidden from screen readers.
+    </p>
+    <p class="note">
+      <code>scroll-target</code> is the pane's inner scroller, which is what gets locked. Keeping it
+      separate from <code>container</code> means the container itself never scrolls, so the panel
+      can be positioned against it with plain <code>inset: 0</code>. Escape is routed by focus, so a
+      contained dialog only answers to Escape pressed inside its own container.
+    </p>
+
+    <div ref="pane" class="contained-pane">
+      <header class="contained-pane__bar">
+        <strong>Project files</strong>
+        <Button size="sm" variant="outline" @click="containedOpen = true">Move to…</Button>
+      </header>
+      <div ref="paneScroll" class="contained-pane__body">
+        <p v-for="n in 14" :key="n" class="contained-pane__row">
+          <code>src/components/File{{ n }}.vue</code>
+        </p>
+      </div>
+    </div>
+
+    <Dialog
+      v-model:open="containedOpen"
+      :container="pane"
+      :scroll-target="paneScroll"
+      size="sm"
+      aria-label="Contained dialog"
+      title="Move 3 files"
+      description="Only this pane is blocked. The page around it keeps working."
+    >
+      <template #default>
+        <p>Try scrolling the page, or clicking “Rename project” above - both still work.</p>
+        <Button variant="secondary" @click="containedNestedOpen = true">
+          Open a nested contained dialog
+        </Button>
+      </template>
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close()">Cancel</Button>
+        <Button @click="close()">Move</Button>
+      </template>
+    </Dialog>
+
+    <Dialog
+      v-model:open="containedNestedOpen"
+      :container="pane"
+      :scroll-target="paneScroll"
+      size="sm"
+      aria-label="Nested contained dialog"
+      title="Are you sure?"
+      description="Stacks inside the same container; Escape closes this one first."
+    >
+      <template #footer="{ close }">
+        <Button variant="ghost" @click="close()">Back</Button>
+      </template>
+    </Dialog>
+
     <h3>Custom exit animations: GSAP and motion-v</h3>
     <p class="note">
       Dialog's panel Teleports to <code>&lt;body&gt;</code>, so it can't be wrapped in
@@ -241,6 +303,11 @@ import type { RequiredActionData } from './RequiredActionDialogContent.vue'
 const cssOpen = shallowRef(false)
 const outerOpen = shallowRef(false)
 const innerOpen = shallowRef(false)
+
+const pane = useTemplateRef<HTMLElement>('pane')
+const paneScroll = useTemplateRef<HTMLElement>('paneScroll')
+const containedOpen = shallowRef(false)
+const containedNestedOpen = shallowRef(false)
 
 const fakeTask = () => new Promise((resolve) => setTimeout(resolve, 1200))
 
@@ -473,11 +540,47 @@ function openRequiredAction() {
      block-size as a hard constraint, so padding alone can't grow past it. */
   block-size: 3.75rem;
 }
+
+/* `position: relative` is required. */
+.contained-pane {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--ui-border, #e4e4e7);
+  border-radius: 0.75rem;
+  max-inline-size: 34rem;
+}
+
+.contained-pane__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-block-end: 1px solid var(--ui-border, #e4e4e7);
+}
+
+/* The scroller is inside the container, not the container itself. */
+.contained-pane__body {
+  overflow-y: auto;
+  max-block-size: 13rem;
+  padding: 0.5rem 1rem;
+}
+
+.contained-pane__row {
+  margin: 0;
+  padding-block: 0.35rem;
+}
 </style>
 
 <!-- Unscoped: the overlay teleports to <body> with Dialog, out of scoped reach. -->
 <style>
 .blurred-overlay {
   backdrop-filter: blur(8px);
+}
+
+/* temporary. */
+.ui-dialog[data-contained] .ui-dialog-panel {
+  max-inline-size: 100%;
+  max-block-size: 100%;
 }
 </style>

--- a/docs/src/demos/DialogDemo.vue
+++ b/docs/src/demos/DialogDemo.vue
@@ -571,16 +571,3 @@ function openRequiredAction() {
   padding-block: 0.35rem;
 }
 </style>
-
-<!-- Unscoped: the overlay teleports to <body> with Dialog, out of scoped reach. -->
-<style>
-.blurred-overlay {
-  backdrop-filter: blur(8px);
-}
-
-/* temporary. */
-.ui-dialog[data-contained] .ui-dialog-panel {
-  max-inline-size: 100%;
-  max-block-size: 100%;
-}
-</style>

--- a/packages/ui/src/components/Dialog.vue
+++ b/packages/ui/src/components/Dialog.vue
@@ -1,15 +1,17 @@
 <template>
-  <Teleport :to="teleportTo">
+  <Teleport :to="teleportTarget">
     <Transition name="ui-dialog" :css="!forceMount">
       <div
         v-if="forceMount || open"
         v-show="open"
+        ref="root"
         class="ui-dialog"
         :class="[`ui-dialog--${position}`, { 'ui-dialog--open': open }]"
         :style="rootStyle"
         :data-ui-theme="themeScope"
         :data-state="isClosing ? 'closing' : 'open'"
         :data-maximized="maximized"
+        :data-contained="contained || undefined"
       >
         <div
           v-if="modal"
@@ -21,7 +23,7 @@
         <div
           ref="panel"
           :role="role"
-          :aria-modal="modal ? 'true' : undefined"
+          :aria-modal="modal && !contained ? 'true' : undefined"
           tabindex="-1"
           :aria-labelledby="title ? titleId : undefined"
           :aria-describedby="description ? descriptionId : undefined"
@@ -150,6 +152,19 @@ export interface DialogProps {
   forceMount?: boolean
   /** Teleport target for the panel/overlay. */
   teleportTo?: string
+  /**
+   * Scopes the dialog to one element instead of the viewport: the overlay dims only
+   * that box, scroll lock and modality apply only inside it, and the rest of the page
+   * stays interactive. Also becomes the teleport target unless `teleportTo` is set.
+   * The element must be positioned (`position: relative` or similar).
+   */
+  container?: DOMTarget
+  /**
+   * Element whose scrolling is locked while open. Defaults to `container`.
+   * Pass the inner scroller when the container itself doesn't scroll - an
+   * absolutely-positioned panel scrolls away with its container's content.
+   */
+  scrollTarget?: DOMTarget
   /** Masks the panel's top/bottom edge as its content scrolls under it, signaling there's more. */
   scrollFade?: boolean
   /** Adds a maximize/restore toggle to the header, filling the viewport when active. */
@@ -173,6 +188,7 @@ import { computed, inject, ref, useId, useTemplateRef } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { useDialog } from '../composables/useDialog'
 import type { DialogOpenChangeDetails } from '../composables/useDialog'
+import type { DOMTarget } from '../composables/dom'
 import { useUiMessages } from '../messages'
 import { useClassMerge, resolveUiPart } from '../classes'
 import { themeScopeKey, useThemedUi } from '../theme'
@@ -220,6 +236,9 @@ defineSlots<{
 
 // Full panel (for FLIP demos and beforeClose measurement, not just scrollable middle).
 const panelEl = useTemplateRef<HTMLElement>('panel')
+// Outermost teleported node. `useInert` spares this rather than `panelEl` — otherwise
+// the overlay is a sibling, goes inert, and stops dispatching the outside-click.
+const rootEl = useTemplateRef<HTMLElement>('root')
 const messages = useUiMessages()
 const cx = useClassMerge()
 const themedUi = useThemedUi(
@@ -228,8 +247,11 @@ const themedUi = useThemedUi(
 )
 const themeScope = inject(themeScopeKey, undefined)
 
-const { isClosing, close, requestClose, cancelClose } = useDialog(open, {
+const { isClosing, close, requestClose, cancelClose, container, contained } = useDialog(open, {
   panelEl,
+  wrapperEl: rootEl,
+  container: () => props.container ?? null,
+  scrollTarget: () => props.scrollTarget ?? null,
   closeOnEsc: () => props.closeOnEsc,
   beforeClose: () => props.beforeClose,
   initialFocus: () => props.initialFocus?.(),
@@ -241,13 +263,19 @@ function onOverlayClick(event: MouseEvent) {
   if (props.closeOnOverlay) requestClose('outside', event)
 }
 
+// An explicit `teleportTo` wins; otherwise a container becomes the target, since a
+// contained dialog rendered at body level would be positioned against the wrong box.
+const teleportTarget = computed<string | HTMLElement>(() =>
+  props.teleportTo === 'body' && container.value ? container.value : props.teleportTo,
+)
+
 const titleId = useId()
 const descriptionId = useId()
 
 // STRUCTURAL: inlined for zero-CSS functionality; align-items/justify-content non-interpolable, padding/size animate instead.
 const isSidePosition = computed(() => props.position === 'left' || props.position === 'right')
 const rootStyle = computed<Record<string, string | number | undefined>>(() => ({
-  position: 'fixed',
+  position: contained.value ? 'absolute' : 'fixed',
   inset: 0,
   zIndex: 'var(--ui-z-dialog, 50)',
   display: 'flex',
@@ -276,7 +304,14 @@ const panelStyle = computed<Record<string, string | undefined>>(() => {
     pointerEvents: props.modal ? undefined : 'auto',
   }
   if (maximized.value) {
-    return { ...base, inlineSize: '100dvw', blockSize: '100dvh', maxBlockSize: '100dvh' }
+    // dvw/dvh are viewport-relative; inside a container "maximized" means filling it.
+    const fill = contained.value ? '100%' : undefined
+    return {
+      ...base,
+      inlineSize: fill ?? '100dvw',
+      blockSize: fill ?? '100dvh',
+      maxBlockSize: fill ?? '100dvh',
+    }
   }
   if (naturalPanelSize.value) {
     return {

--- a/packages/ui/src/components/Dialog.vue
+++ b/packages/ui/src/components/Dialog.vue
@@ -211,7 +211,6 @@ const props = withDefaults(defineProps<DialogProps>(), {
   closeOnEsc: true,
   closeOnOverlay: true,
   forceMount: false,
-  teleportTo: 'body',
   scrollFade: true,
   maximizable: false,
 })
@@ -265,9 +264,12 @@ function onOverlayClick(event: MouseEvent) {
 
 // An explicit `teleportTo` wins; otherwise a container becomes the target, since a
 // contained dialog rendered at body level would be positioned against the wrong box.
-const teleportTarget = computed<string | HTMLElement>(() =>
-  props.teleportTo === 'body' && container.value ? container.value : props.teleportTo,
-)
+const teleportTarget = computed<string | HTMLElement | undefined>(() => {
+  if (props.teleportTo) {
+    return props.teleportTo
+  }
+  return container.value ?? 'body'
+})
 
 const titleId = useId()
 const descriptionId = useId()

--- a/packages/ui/src/composables/dom.ts
+++ b/packages/ui/src/composables/dom.ts
@@ -1,0 +1,58 @@
+import { isClient } from '@vueuse/core'
+
+export type DOMTarget = HTMLElement | string | null
+
+export function resolveDOMTarget(target: undefined): undefined
+export function resolveDOMTarget(target: DOMTarget): HTMLElement | null
+export function resolveDOMTarget(target: DOMTarget | undefined): HTMLElement | null | undefined
+
+export function resolveDOMTarget(target: DOMTarget | undefined): HTMLElement | null | undefined {
+  if (target === undefined) return undefined
+  if (target === null) return null
+  if (!isClient) return null
+  if (typeof target === 'string') {
+    try {
+      return document.querySelector<HTMLElement>(target)
+    } catch {
+      // for invalid selector
+      return null
+    }
+  }
+  return target
+}
+
+import { shallowRef, toValue, watch, type ShallowRef, type MaybeRefOrGetter } from 'vue'
+import { tryOnMounted } from '@vueuse/core'
+
+export interface UseDOMTargetReturn {
+  /** The resolved element, or `null` while unresolved. */
+  el: Readonly<ShallowRef<HTMLElement | null>>
+  /** Manual refresh. Only useful for selectors, whose match can change silently. */
+  refresh: () => void
+}
+
+/**
+ * Normalises any `DOMTarget` — element, ref, `useTemplateRef`, getter, or selector —
+ * into a plain element ref.
+ *
+ * This is the only place selectors are understood. The primitives downstream
+ * (`useScrollLock`, `useLayer`) take elements, so a selector resolves once here and
+ * every consumer sees the same node rather than each running its own query.
+ *
+ * A selector has no reactive dependency on the DOM, so it is resolved on mount and
+ * whenever the target itself changes. If the matching element can be replaced after
+ * that, pass a ref instead — or call `resolve()` yourself.
+ */
+export function useDOMTarget(target: MaybeRefOrGetter<DOMTarget>): UseDOMTargetReturn {
+  const el = shallowRef<HTMLElement | null>(null)
+
+  const refresh = () => {
+    el.value = resolveDOMTarget(toValue(target))
+  }
+
+  watch(() => toValue(target), refresh, { immediate: true })
+
+  tryOnMounted(refresh)
+
+  return { el, refresh }
+}

--- a/packages/ui/src/composables/useDialog.ts
+++ b/packages/ui/src/composables/useDialog.ts
@@ -1,7 +1,10 @@
-import { nextTick, onMounted, onScopeDispose, shallowRef, toValue, watch } from 'vue'
+import { computed, nextTick, onMounted, onScopeDispose, shallowRef, toValue, watch } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { useLayer } from './useLayerStack'
+import { useScrollLock } from './useScrollLock'
+import { useInert } from './useInert'
+import { useDOMTarget, type DOMTarget } from './dom'
 
 export type DialogCloseReason = 'trigger' | 'escape' | 'outside' | 'programmatic'
 
@@ -13,6 +16,24 @@ export interface DialogOpenChangeDetails {
 
 export interface UseDialogOptions {
   panelEl: Ref<HTMLElement | null>
+  /**
+   * Outermost teleported node — the element the overlay and panel both live inside.
+   * `useInert` spares this rather than `panelEl`, otherwise the overlay is a sibling
+   * and goes inert, silently killing outside-click. Falls back to `panelEl`.
+   */
+  wrapperEl?: Ref<HTMLElement | null>
+  /**
+   * Scopes the dialog to one element: the overlay, scroll lock and modality apply
+   * only inside it, and the rest of the page stays interactive.
+   * Omit for a page-level dialog.
+   */
+  container?: MaybeRefOrGetter<DOMTarget>
+  /**
+   * Element whose scrolling is locked while open. Defaults to `container`, then
+   * `document.body`. Keeping it separate lets the container stay unscrolled, so an
+   * absolutely-positioned panel doesn't drift out of view.
+   */
+  scrollTarget?: MaybeRefOrGetter<DOMTarget>
   closeOnEsc?: MaybeRefOrGetter<boolean>
   /** Called before the model flips to false. Call `cancel()` on the details to veto the close. Components wire this to their `open-change` emit. */
   onOpenChange?: (value: boolean, details: DialogOpenChangeDetails) => void
@@ -37,34 +58,6 @@ function getFocusable(root: HTMLElement): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
     (el) => el.getClientRects().length > 0,
   )
-}
-
-// Shared across all dialog instances so nested/stacked dialogs don't restore
-// body overflow while a sibling is still open.
-let scrollLockCount = 0
-let previousBodyOverflow = ''
-let previousBodyPaddingRight = ''
-
-function lockBodyScroll() {
-  if (scrollLockCount++ === 0) {
-    // Scrollbar removal shifts content left; compensate with padding
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
-    previousBodyOverflow = document.body.style.overflow
-    previousBodyPaddingRight = document.body.style.paddingRight
-    document.body.style.overflow = 'hidden'
-    if (scrollbarWidth > 0) {
-      const currentPaddingRight =
-        Number.parseFloat(getComputedStyle(document.body).paddingRight) || 0
-      document.body.style.paddingRight = `${currentPaddingRight + scrollbarWidth}px`
-    }
-  }
-}
-
-function unlockBodyScroll() {
-  if (scrollLockCount > 0 && --scrollLockCount === 0) {
-    document.body.style.overflow = previousBodyOverflow
-    document.body.style.paddingRight = previousBodyPaddingRight
-  }
 }
 
 /** Headless dialog: cancelable close, Escape, Tab trap, scroll lock, focus save/restore. */
@@ -114,30 +107,60 @@ export function useDialog(open: Ref<boolean>, options: UseDialogOptions) {
     requestClose('programmatic')
   }
 
+  const { el: container } = useDOMTarget(() => toValue(options.container) ?? null)
+  const { el: scrollTarget } = useDOMTarget(() => toValue(options.scrollTarget) ?? null)
+  const contained = computed(() => container.value !== null)
+
   if (typeof window === 'undefined') {
-    return { isClosing, close, requestClose, cancelClose }
+    return { isClosing, close, requestClose, cancelClose, container, contained }
   }
 
-  const layer = useLayer()
+  const contentEl = () => options.wrapperEl?.value ?? panelEl.value
+
+  const layer = useLayer({
+    // null -> page-level
+    scope: container,
+    content: contentEl,
+    onDismiss: (_reason, event) => {
+      if (!toValue(options.closeOnEsc ?? true)) return
+      requestClose('escape', event)
+    },
+  })
+
+  const scrollLocked = useScrollLock({
+    target: () => scrollTarget.value ?? container.value ?? document.body,
+  })
+
+  // Contained only, for now. Applying inert page-wide would also silence anything
+  // rendered outside the dialog — Toaster, PopoverHost, skip links — which the
+  // Tab trap does not. That is a separate change from this feature.
+  const inerted = useInert({
+    root: () => container.value ?? document.body,
+    content: contentEl,
+  })
+
   let previouslyFocused: HTMLElement | null = null
   let active = false
-  // Snapshot at activate() to avoid desync on reactive modal flip mid-open.
+  // Snapshot at activate() to avoid desync on reactive flips mid-open.
   let modalActive = true
+  let containedActive = false
   const isOpen = shallowRef(false)
 
   function onDocumentKeydown(event: KeyboardEvent) {
-    // Only topmost layer reacts to Escape/Tab.
-    if (!layer.isTopmost()) return
-
-    if (event.key === 'Escape' && toValue(options.closeOnEsc ?? true)) {
-      event.preventDefault()
-      requestClose('escape', event)
-      return
-    }
+    // Escape is dispatched by the layer stack, which picks a single winner by focus —
+    // self-checking isTopmost() here would close both dialogs in sibling containers.
     if (event.key !== 'Tab' || !modalActive) return
+    if (!layer.isTopmost()) return
 
     const panel = panelEl.value
     if (!panel) return
+    const current = document.activeElement
+    const inside = current instanceof HTMLElement && panel.contains(current)
+
+    // cycle while focus is inside, but if the user intentionally focused
+    // something outside, do not drag the focus back.
+    if (!inside && containedActive) return
+
     const focusables = getFocusable(panel)
     if (focusables.length === 0) {
       event.preventDefault()
@@ -146,9 +169,8 @@ export function useDialog(open: Ref<boolean>, options: UseDialogOptions) {
     }
     const first = focusables[0]
     const last = focusables[focusables.length - 1]
-    const current = document.activeElement
 
-    if (!(current instanceof HTMLElement) || !panel.contains(current)) {
+    if (!inside) {
       event.preventDefault()
       first.focus()
     } else if (event.shiftKey && (current === first || current === panel)) {
@@ -166,12 +188,15 @@ export function useDialog(open: Ref<boolean>, options: UseDialogOptions) {
     if (active) return
     active = true
     modalActive = toValue(options.modal ?? true)
+    containedActive = contained.value
     layer.push()
     isOpen.value = true
     if (modalActive) {
       previouslyFocused =
         document.activeElement instanceof HTMLElement ? document.activeElement : null
-      lockBodyScroll()
+      scrollLocked.value = true
+      // inert blurs whatever is focused inside it, so this must happen before the focus steal.
+      if (containedActive) inerted.value = true
       // Focus immediately (don't wait for animation).
       nextTick(() => {
         const panel = panelEl.value
@@ -188,8 +213,10 @@ export function useDialog(open: Ref<boolean>, options: UseDialogOptions) {
     layer.pop()
     isOpen.value = false
     if (modalActive) {
-      unlockBodyScroll()
-      previouslyFocused?.focus({ preventScroll: true })
+      scrollLocked.value = false
+      inerted.value = false
+      // the opener may have unmounted while we were open.
+      if (previouslyFocused?.isConnected) previouslyFocused.focus({ preventScroll: true })
     }
     previouslyFocused = null
     // Clear pending close on raw model writes mid-close.
@@ -205,5 +232,5 @@ export function useDialog(open: Ref<boolean>, options: UseDialogOptions) {
 
   onScopeDispose(() => deactivate())
 
-  return { isClosing, close, requestClose, cancelClose }
+  return { isClosing, close, requestClose, cancelClose, container, scrollTarget, contained }
 }

--- a/packages/ui/src/composables/useInert.ts
+++ b/packages/ui/src/composables/useInert.ts
@@ -1,0 +1,119 @@
+import type { MaybeRefOrGetter, WritableComputedRef } from 'vue'
+import { computed, shallowRef, toValue, watch } from 'vue'
+import { isClient, tryOnScopeDispose } from '@vueuse/core'
+
+interface InertState {
+  /** How many layers currently lock this element inert. */
+  count: number
+  /** Initial inert value. */
+  initial: boolean
+}
+
+const inertStates = new WeakMap<HTMLElement, InertState>()
+
+function retain(el: HTMLElement) {
+  const state = inertStates.get(el)
+  if (state) {
+    state.count++
+    return
+  }
+  inertStates.set(el, { count: 1, initial: el.inert })
+  el.inert = true
+}
+
+function release(el: HTMLElement) {
+  const state = inertStates.get(el)
+  if (!state) return
+  if (--state.count > 0) return
+
+  inertStates.delete(el)
+  el.inert = state.initial
+}
+
+/**
+ * Every element between `content` and `root` that is *not* on the path from one to the
+ * other — i.e. the siblings at each level. Marking those inert propagates to their
+ * subtrees, while `content` and its ancestors stay interactive.
+ *
+ * If `content` lives outside `root` (a panel teleported elsewhere), nothing inside
+ * `root` needs to stay reachable, so the whole of it goes inert.
+ */
+function collectInertTargets(root: HTMLElement, content: HTMLElement): HTMLElement[] {
+  const targets: HTMLElement[] = []
+
+  if (!root.contains(content)) {
+    for (const child of root.children) {
+      if (child instanceof HTMLElement) targets.push(child)
+    }
+    return targets
+  }
+
+  let node: HTMLElement = content
+  while (node !== root) {
+    const parent = node.parentElement
+    // necessary to prevent accidentally leaving the shadow root.
+    if (!parent) break
+    for (const sibling of parent.children) {
+      if (sibling !== node && sibling instanceof HTMLElement) targets.push(sibling)
+    }
+    node = parent
+  }
+
+  return targets
+}
+
+export interface UseInertOptions {
+  /**
+   * Region to make inert. Defaults to `document.body`.
+   */
+  root?: MaybeRefOrGetter<HTMLElement | null>
+  /** The element that stays interactive, along with its ancestors and subtree. */
+  content: MaybeRefOrGetter<HTMLElement | null>
+  initial?: boolean
+}
+
+export type UseInertReturn = WritableComputedRef<boolean>
+
+export function useInert(options: UseInertOptions): UseInertReturn {
+  const { root, content, initial = false } = options
+
+  const resolveRoot = (): HTMLElement | null => {
+    if (root === undefined) return isClient ? document.body : null
+    return toValue(root) ?? null
+  }
+
+  const desired = shallowRef(initial)
+  let held: HTMLElement[] = []
+
+  const syncInert = () => {
+    const rootEl = desired.value ? resolveRoot() : null
+    const contentEl = desired.value ? (toValue(content) ?? null) : null
+
+    const next = rootEl && contentEl ? collectInertTargets(rootEl, contentEl) : []
+
+    // Retain the new set before releasing the old one
+    for (const el of next) retain(el)
+    for (const el of held) release(el)
+    held = next
+  }
+
+  // `post` because both root and content are usually template refs, which are only
+  // populated once the patch that created them has finished.
+  watch([resolveRoot, () => toValue(content)], syncInert, { flush: 'post' })
+
+  tryOnScopeDispose(() => {
+    desired.value = false
+    syncInert()
+  })
+
+  if (initial) syncInert()
+
+  return computed<boolean>({
+    get: () => desired.value,
+    set(v) {
+      if (v === desired.value) return
+      desired.value = v
+      syncInert()
+    },
+  })
+}

--- a/packages/ui/src/composables/useLayerStack.ts
+++ b/packages/ui/src/composables/useLayerStack.ts
@@ -1,24 +1,114 @@
-// Stack for Escape-to-close topmost-only behavior.
-let stack: symbol[] = []
+import { shallowRef, toValue, type MaybeRefOrGetter } from 'vue'
+import { isClient, tryOnScopeDispose } from '@vueuse/core'
+
+export type DismissReason = 'escape'
+
+interface LayerEntry {
+  id: symbol
+  /** Resolved lazily - a template ref may still be null when the layer is pushed. */
+  scope: () => HTMLElement | null
+  /** The content itself, which may be teleported outside its own scope. */
+  content: () => HTMLElement | null
+  onDismiss?: (reason: DismissReason, event: Event) => boolean | void
+}
+
+const stack = shallowRef<LayerEntry[]>([])
+
+function contends(a: HTMLElement | null, b: HTMLElement | null) {
+  if (a === null || b === null) return true
+  return a === b || a.contains(b) || b.contains(a)
+}
+
+function owns(entry: LayerEntry, origin: Node | null) {
+  const scope = entry.scope()
+  if (scope === null) return true
+  if (!origin) return false
+  return scope.contains(origin) || entry.content()?.contains(origin) === true
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Escape' || e.defaultPrevented) return
+
+  const layers = stack.value
+  const origin = (e.target as Node | null) ?? document.activeElement
+
+  // newest owning layer wins.
+  let winner: LayerEntry | undefined
+  for (let i = layers.length - 1; i >= 0; i--) {
+    if (owns(layers[i], origin)) {
+      winner = layers[i]
+      break
+    }
+  }
+
+  if (!winner?.onDismiss) return
+  // dialog with `closeOnEsc: false` shouldn't leak the key to the one beneath it.
+  if (winner.onDismiss('escape', e) !== false) e.preventDefault()
+}
+
+let listening = false
+
+function syncKeydownListener() {
+  if (!isClient) return
+  const shouldListen = stack.value.length > 0
+  if (shouldListen === listening) return
+
+  listening = shouldListen
+  if (shouldListen) document.addEventListener('keydown', onKeydown, true)
+  else document.removeEventListener('keydown', onKeydown, true)
+}
 
 export interface Layer {
-  /** Registers this layer as open, on top of whatever's already open. */
   push: () => void
-  /** Unregisters this layer — call on close, unconditionally safe to call twice. */
   pop: () => void
-  /** True only for the single most-recently-pushed layer still on the stack. */
   isTopmost: () => boolean
 }
 
-export function useLayer(): Layer {
+export interface UseLayerOptions {
+  /**
+   * Region this layer owns. Omit for page-level layers.
+   */
+  scope?: MaybeRefOrGetter<HTMLElement | null>
+  /** The content itself, which may be teleported outside its own scope. */
+  content?: MaybeRefOrGetter<HTMLElement | null>
+  onDismiss?: (reason: DismissReason, event: Event) => boolean | void
+}
+
+export function useLayer(options: UseLayerOptions = {}): Layer {
   const id = Symbol('layer')
-  return {
-    push: () => {
-      if (!stack.includes(id)) stack.push(id)
-    },
-    pop: () => {
-      stack = stack.filter((layerId) => layerId !== id)
-    },
-    isTopmost: () => stack.length > 0 && stack[stack.length - 1] === id,
+
+  const entry: LayerEntry = {
+    id,
+    scope: () => toValue(options.scope) ?? null,
+    content: () => toValue(options.content) ?? null,
+    onDismiss: options.onDismiss,
   }
+
+  const push = () => {
+    if (stack.value.some((e) => e.id === id)) return
+    stack.value = [...stack.value, entry]
+    syncKeydownListener()
+  }
+
+  const pop = () => {
+    if (!stack.value.some((e) => e.id === id)) return
+    stack.value = stack.value.filter((e) => e.id !== id)
+    syncKeydownListener()
+  }
+
+  tryOnScopeDispose(pop)
+
+  const isTopmost = () => {
+    const layers = stack.value
+    const index = layers.findIndex((e) => e.id === id)
+    if (index === -1) return false
+
+    const scope = entry.scope()
+    for (let i = index + 1; i < layers.length; i++) {
+      if (contends(layers[i].scope(), scope)) return false
+    }
+    return true
+  }
+
+  return { push, pop, isTopmost }
 }

--- a/packages/ui/src/composables/useScrollLock.ts
+++ b/packages/ui/src/composables/useScrollLock.ts
@@ -1,0 +1,179 @@
+import type { MaybeRefOrGetter, WritableComputedRef } from 'vue'
+import { computed, shallowRef, toValue, watch } from 'vue'
+import { isClient, isIOS, tryOnScopeDispose, useEventListener } from '@vueuse/core'
+
+export const ScrollbarWidthVariable = '--ui-scrollbar-width'
+
+/** Overwritten inline style. */
+interface StylePatch {
+  el: HTMLElement
+  prop: string
+  /** Inline value before patch - `''` when there was none. */
+  value: string
+  priority: string
+  /** Inline value after patch. Used to detect external modifications. */
+  applied: string
+}
+
+interface LockState {
+  holders: Set<symbol>
+  patches: StylePatch[]
+  /** Element carrying `--ui-scrollbar-width`, or null if never set. */
+  varHolder: HTMLElement | null
+  stopTouchMove?: () => void
+}
+
+const locks = new WeakMap<HTMLElement, LockState>()
+
+export interface UseScrollLockOptions {
+  /**
+   * Element to lock. Defaults to `document.body`.
+   */
+  target?: MaybeRefOrGetter<HTMLElement | null>
+  initial?: boolean
+}
+
+export type UseScrollLockReturn = WritableComputedRef<boolean>
+
+export function useScrollLock(options: UseScrollLockOptions = {}): UseScrollLockReturn {
+  const { target, initial = false } = options
+
+  // Lazy so `document` is never touched during SSR.
+  const resolveTarget = (): HTMLElement | null => {
+    if (target === undefined) return isClient ? document.body : null
+    return toValue(target) ?? null
+  }
+
+  const desired = shallowRef(initial)
+  let held: HTMLElement | null = null
+  let release: (() => void) | null = null
+
+  const syncLock = () => {
+    const next = desired.value ? resolveTarget() : null
+    if (next === held) return
+
+    // before locking the new element, release the previous one:
+    release?.()
+    held = next
+    release = next ? acquireLock(next) : null
+  }
+
+  watch(resolveTarget, syncLock, { flush: 'sync' })
+  tryOnScopeDispose(() => {
+    desired.value = false
+    syncLock()
+  })
+
+  if (initial) syncLock()
+
+  return computed<boolean>({
+    get: () => desired.value,
+    set(v) {
+      if (v === desired.value) return
+      desired.value = v
+      syncLock()
+    },
+  })
+}
+
+function patchStyle(state: LockState, el: HTMLElement, prop: string, applied: string) {
+  state.patches.push({
+    el,
+    prop,
+    value: el.style.getPropertyValue(prop),
+    priority: el.style.getPropertyPriority(prop),
+    applied,
+  })
+  el.style.setProperty(prop, applied)
+}
+
+function acquireLock(element: HTMLElement): () => void {
+  const holder = Symbol('holder')
+
+  const existing = locks.get(element)
+  if (existing) {
+    existing.holders.add(holder)
+    return () => releaseLock(element, holder)
+  }
+
+  const isBody = element === document.body
+  const computedStyles = getComputedStyle(element)
+
+  const scrollbarWidth = isBody
+    ? window.innerWidth - document.documentElement.clientWidth
+    : element.offsetWidth -
+      element.clientWidth -
+      (Number.parseFloat(computedStyles.borderInlineStartWidth) || 0) -
+      (Number.parseFloat(computedStyles.borderInlineEndWidth) || 0)
+
+  const state: LockState = {
+    holders: new Set([holder]),
+    patches: [],
+    varHolder: null,
+  }
+  locks.set(element, state)
+
+  const overflowTarget = isBody ? document.documentElement : element
+  patchStyle(state, overflowTarget, 'overflow', 'hidden')
+
+  if (isBody) patchStyle(state, overflowTarget, 'overscroll-behavior', 'contain')
+
+  if (scrollbarWidth > 0) {
+    const existing = Number.parseFloat(computedStyles.paddingInlineEnd) || 0
+    patchStyle(state, element, 'padding-inline-end', `${existing + scrollbarWidth}px`)
+
+    state.varHolder = isBody ? document.documentElement : element
+    state.varHolder.style.setProperty(ScrollbarWidthVariable, `${scrollbarWidth}px`)
+  }
+
+  if (isBody && isIOS) {
+    state.stopTouchMove = useEventListener(
+      document,
+      'touchmove',
+      (e: TouchEvent) => {
+        if (e.touches.length > 1) return
+        // don't block a genuinely scrollable region inside the locked element:
+        if (e.target instanceof Element && checkOverflowScroll(e.target, element)) return
+        if (e.cancelable) e.preventDefault()
+      },
+      { passive: false },
+    )
+  }
+
+  return () => releaseLock(element, holder)
+}
+
+function releaseLock(element: HTMLElement, holder: symbol) {
+  const state = locks.get(element)
+  // if already released or never held -> no-op
+  if (!state || !state.holders.delete(holder)) return
+  // if something still holds the lock -> no-op
+  if (state.holders.size > 0) return
+
+  locks.delete(element)
+  state.stopTouchMove?.()
+
+  state.varHolder?.style.removeProperty(ScrollbarWidthVariable)
+
+  for (const p of state.patches) {
+    // if something modified us while locked, give it a priority
+    if (p.el.style.getPropertyValue(p.prop) !== p.applied) continue
+    if (p.value) p.el.style.setProperty(p.prop, p.value, p.priority)
+    else p.el.style.removeProperty(p.prop)
+  }
+}
+
+// modified from: https://github.com/vueuse/vueuse/blob/main/packages/core/useScrollLock/index.ts
+// the reference has a bug, where if `document.body` is passed, parentNode will traverse until <html> tag
+function checkOverflowScroll(ele: Element, terminator: HTMLElement): boolean {
+  for (let el: Element | null = ele; el && el !== terminator; el = el.parentElement) {
+    const { overflowX, overflowY } = getComputedStyle(el)
+    if (overflowY === 'scroll' || (overflowY === 'auto' && el.clientHeight < el.scrollHeight)) {
+      return true
+    }
+    if (overflowX === 'scroll' || (overflowX === 'auto' && el.clientWidth < el.scrollWidth)) {
+      return true
+    }
+  }
+  return false
+}

--- a/packages/ui/src/composables/useScrollLock.ts
+++ b/packages/ui/src/composables/useScrollLock.ts
@@ -113,10 +113,8 @@ function acquireLock(element: HTMLElement): () => void {
   }
   locks.set(element, state)
 
-  const overflowTarget = isBody ? document.documentElement : element
-  patchStyle(state, overflowTarget, 'overflow', 'hidden')
-
-  if (isBody) patchStyle(state, overflowTarget, 'overscroll-behavior', 'contain')
+  patchStyle(state, element, 'overflow', 'hidden')
+  patchStyle(state, element, 'overscroll-behavior', 'contain')
 
   if (scrollbarWidth > 0) {
     const existing = Number.parseFloat(computedStyles.paddingInlineEnd) || 0

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -202,7 +202,7 @@ export type {
 export { toast, useToastQueue } from './composables/useToast'
 export type { ToastEntry, ToastFn, ToastOptions, ToastVariant } from './composables/useToast'
 export { useLayer } from './composables/useLayerStack'
-export type { Layer } from './composables/useLayerStack'
+export type { Layer, UseLayerOptions } from './composables/useLayerStack'
 
 export {
   defaultMessages,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -201,6 +201,8 @@ export type {
 } from './composables/useColorScheme'
 export { toast, useToastQueue } from './composables/useToast'
 export type { ToastEntry, ToastFn, ToastOptions, ToastVariant } from './composables/useToast'
+export { useDOMTarget, resolveDOMTarget } from './composables/dom'
+export type { DOMTarget } from './composables/dom'
 export { useLayer } from './composables/useLayerStack'
 export type { Layer, UseLayerOptions } from './composables/useLayerStack'
 

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -1080,6 +1080,10 @@
     transform-origin: center;
     outline: none;
   }
+  .ui-dialog[data-contained] .ui-dialog-panel {
+    /* When in container, use % instead of dvh */
+    max-block-size: 85%;
+  }
 
   .ui-dialog-panel--sm {
     inline-size: min(22rem, 100%);


### PR DESCRIPTION
Closes #13 

For now, I implemented only the `Dialog` part, but adapting to a `Drawer` should be simple.