### PR TITLE
fix(spacing): symmetric internal padding in Dialog, Card, Tour, confirm-popover

### DIFF
--- a/.changeset/spacing-symmetry.md
+++ b/.changeset/spacing-symmetry.md
@@ -1,0 +1,5 @@
+---
+'vael-ui': patch
+---
+
+Fixes inconsistent internal spacing in Dialog, Card, Tour, and confirmAction's popover surface, where the gap on one side of a header/body/footer-style transition was silently double-counted against the other, making the two sides unequal (e.g. Dialog's body→footer gap was exactly double its header→body gap). Also fixes Tour rendering with doubled outer padding — its own header/actions padding was stacking on top of Popover's shared body padding.

--- a/packages/ui/src/components/Card/Card.css
+++ b/packages/ui/src/components/Card/Card.css
@@ -31,7 +31,7 @@
     padding-block-start: 0.75rem;
   }
   .ui-card-body:has(+ .ui-card-footer) {
-    padding-block-end: 0.75rem;
+    padding-block-end: 0;
   }
   .ui-card-footer {
     display: flex;

--- a/packages/ui/src/components/Dialog/Dialog.css
+++ b/packages/ui/src/components/Dialog/Dialog.css
@@ -81,7 +81,7 @@
     padding-block-start: 0.75rem;
   }
   .ui-dialog-body:has(+ .ui-dialog-footer) {
-    padding-block-end: 0.75rem;
+    padding-block-end: 0;
   }
 
   .ui-dialog-footer {

--- a/packages/ui/src/components/Tour/Tour.css
+++ b/packages/ui/src/components/Tour/Tour.css
@@ -21,6 +21,12 @@
     }
   }
 
+  /* Popover's own 1rem body padding would otherwise stack with Tour's own
+     header/actions padding below, doubling the outer margin. */
+  .ui-popover-body:has(.ui-tour-default-content) {
+    padding: 0;
+  }
+
   /* Header/actions are sticky within Popover's own scroll body, so a long
      description scrolls on its own without taking the title or buttons
      with it. */
@@ -55,7 +61,7 @@
   }
   .ui-tour-description {
     margin: 0;
-    padding: 0.375rem 1rem;
+    padding: 0.5rem 1rem 0;
     color: var(--ui-text-muted);
     font-size: 0.875rem;
     line-height: 1.45;

--- a/packages/ui/src/components/shared/confirm-popover.css
+++ b/packages/ui/src/components/shared/confirm-popover.css
@@ -1,12 +1,13 @@
 @layer ui-components {
   /* confirmAction's surface: 'popover' body — Popover has no separate
      header/footer slots the way Dialog does, so title/description/actions
-     all live in this one block; sizing matches Dialog's own title/
-     description scale for visual consistency across both surfaces. */
+     all live in this one block, inside Popover's own 1rem body padding.
+     0.5rem keeps the same 2:1 edge-to-interior ratio Tour uses in the same
+     Popover body. */
   .ui-confirm-popover {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.5rem;
     max-inline-size: var(--ui-confirm-popover-width, 18rem);
   }
   .ui-confirm-popover-title {
@@ -25,6 +26,5 @@
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
-    margin-block-start: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- Dialog and Card's body→footer gap was silently double-counted against header→body (both sides added padding for the same transition instead of one owning it), making it exactly 2x header→body. Fixed by letting the footer alone own the gap, matching how header→body already works.
- Tour had the same double-count on description→actions, plus its own header/actions padding was stacking on top of Popover's shared `.ui-popover-body` padding (1rem), doubling the outer margin (2rem effective edge vs 0.5rem interior — a ~4:1 ratio). Zeroed Popover's body padding specifically when it wraps Tour content, so Tour's own padding is the single source of outer spacing.
- confirmAction's popover surface (`shared/confirm-popover.css`) had no edge padding of its own — all of it came from Popover's shared 1rem — with interior gaps too tight relative to that (previously 0.35rem/0.6rem asymmetric, briefly over-corrected to a too-tight uniform 0.25rem). Now 0.5rem, matching the same 2:1 edge-to-interior ratio Tour uses in the same Popover body.

All four now follow one consistent, deliberate 2:1 edge-to-interior ratio, with every transition owned by exactly one side.

## Verification
- Real rendered measurement (Playwright) at true 16px root font-size (the docs site itself renders at 14px, which was a confound during review): Dialog header→body and body→footer both measured exactly 12px. Tour's interior gaps measured exactly equal both sides, and its outer margin dropped from double (32px) to single (16px) after the Popover body-padding fix.
- Full monorepo `pnpm build`, `pnpm typecheck:only`, and `pnpm --filter vael-ui test` (691/691) all pass clean from a from-scratch rebuild.

## Test plan
- [x] `pnpm build` (root) — clean
- [x] `pnpm typecheck:only` — clean
- [x] `pnpm --filter vael-ui test` — 691/691 passed
- [x] Real Playwright render + pixel measurement of Dialog and Tour at true 16px root