### PR TITLE
fix(vapor): merge external class instead of overwriting internal styling

### DIFF
--- a/.changeset/vapor-class-merge-fix.md
+++ b/.changeset/vapor-class-merge-fix.md
@@ -1,0 +1,9 @@
+---
+'vael-ui': patch
+---
+
+Fixes an external `class` passed to a component (e.g. `<Message class="my-class">`) silently replacing the component's own internal styling classes instead of merging with them, under `vael-ui/vapor`. 36 components (Accordion, Card, Checkbox, DataTable, Tag, Toolbar, and others) now explicitly merge fallthrough attrs instead of relying on Vapor's implicit fallthrough, which doesn't reliably merge `class` on a component that already binds its own.
+
+Components whose root wraps content in `<Transition>` (Dialog, Popover, Message, Tooltip, and others) are not covered by this fix — that's a separate, upstream Vue 3.6 Vapor limitation in how `<Transition>` itself handles fallthrough attrs, tracked separately.
+
+Also bumps the `vue` dependency to `3.6.0-rc.3`, which fixes `AnimatePresence`/`<Transition>` deferring exit removal through a `<Teleport>` nested inside a component (e.g. a force-mounted `Dialog`) — the imperative `beforeClose` fallback is no longer required for that case, though it remains supported.

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "vael-ui": "workspace:*",
     "vee-validate": "^4.15.1",
     "vite-ssg": "^28.3.0",
-    "vue": "3.6.0-rc.2",
+    "vue": "3.6.0-rc.3",
     "vue-i18n": "^11.4.8",
     "vue-router": "^5.2.0"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -78,7 +78,7 @@
     "vite": "^8.2.1",
     "vitest": "^4.1.10",
     "vitest-browser-vue": "^2.1.0",
-    "vue": "3.6.0-rc.2",
+    "vue": "3.6.0-rc.3",
     "vue-component-type-helpers": "^3.3.9",
     "vue-tsc": "^3.3.9"
   },

--- a/packages/ui/src/components/Accordion/Accordion.vue
+++ b/packages/ui/src/components/Accordion/Accordion.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="root" :class="rootPart.class" :style="rootPart.style">
+  <div ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
     <slot />
   </div>
 </template>
@@ -19,11 +19,14 @@ export const accordionKey: InjectionKey<AccordionContext> = Symbol('ui-accordion
 <script setup lang="ts">
 import './Accordion.css'
 import '../shared/tokens.css'
-import { computed, provide, useTemplateRef } from 'vue'
+import { computed, provide, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const value = defineModel<string | string[] | null>('value', { default: null })
 
 const props = withDefaults(

--- a/packages/ui/src/components/AccordionItem/AccordionItem.vue
+++ b/packages/ui/src/components/AccordionItem/AccordionItem.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    v-bind="attrs"
     :class="itemPart.class"
     :style="itemPart.style"
     :data-motion="ctx.motionCss() ? undefined : 'off'"
@@ -57,13 +58,16 @@
 <script setup lang="ts">
 import './AccordionItem.css'
 import '../shared/tokens.css'
-import { computed, inject, useId, useTemplateRef } from 'vue'
+import { computed, inject, useAttrs, useId, useTemplateRef } from 'vue'
 import { accordionKey } from '../Accordion/Accordion.vue'
 import { useCollapse } from '../../composables/useCollapse'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = defineProps<{
   value: string
   title?: string

--- a/packages/ui/src/components/Avatar/Avatar.vue
+++ b/packages/ui/src/components/Avatar/Avatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <span ref="root" :class="rootPart.class" :style="rootPart.style">
+  <span ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
     <span class="ui-avatar-frame">
       <span :class="fallbackPart.class" :style="fallbackPart.style">
         <slot>{{ initials }}</slot>
@@ -30,11 +30,14 @@
 <script setup lang="ts">
 import './Avatar.css'
 import '../shared/tokens.css'
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     src?: string

--- a/packages/ui/src/components/AvatarGroup/AvatarGroup.vue
+++ b/packages/ui/src/components/AvatarGroup/AvatarGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="root" :class="rootPart.class" :style="rootPart.style">
+  <div ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
     <slot />
     <Avatar
       v-if="overflowCount > 0"
@@ -15,12 +15,15 @@
 <script setup lang="ts">
 import './AvatarGroup.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import Avatar from '../Avatar/Avatar.vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     /** Sizes the generated overflow avatar; slotted `Avatar`s keep their own `size` prop. */

--- a/packages/ui/src/components/Badge/Badge.vue
+++ b/packages/ui/src/components/Badge/Badge.vue
@@ -1,5 +1,5 @@
 <template>
-  <span ref="root" :class="rootPart.class" :style="rootPart.style">
+  <span ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
     <span v-if="!dot" :key="count" :class="contentClass" :style="contentStyle()">
       <slot>{{ display }}</slot>
     </span>
@@ -10,11 +10,14 @@
 <script setup lang="ts">
 import './Badge.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     variant?: 'primary' | 'muted' | 'success' | 'warning' | 'danger' | 'info'

--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.vue
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.vue
@@ -1,5 +1,11 @@
 <template>
-  <nav ref="root" :aria-label="ariaLabel" :class="rootPart.class" :style="rootPart.style">
+  <nav
+    ref="root"
+    v-bind="attrs"
+    :aria-label="ariaLabel"
+    :class="rootPart.class"
+    :style="rootPart.style"
+  >
     <ol v-scroll-mask="wrap ? false : 'x'" :class="listPart.class" :style="listPart.style">
       <template v-if="items">
         <template v-for="(item, index) in items" :key="index">
@@ -44,7 +50,7 @@ export interface BreadcrumbItemData {
 <script setup lang="ts" generic="T extends BreadcrumbItemData = BreadcrumbItemData">
 import './Breadcrumb.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import BreadcrumbItem from '../BreadcrumbItem/BreadcrumbItem.vue'
 import BreadcrumbSeparator from '../BreadcrumbSeparator/BreadcrumbSeparator.vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
@@ -53,6 +59,9 @@ import { useThemedUi } from '../../theme'
 import { useUiMessages } from '../../messages'
 import { vScrollMask } from '../../directives/vScrollMask'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     /** Data-driven alternative to composing `BreadcrumbItem`/`BreadcrumbSeparator` yourself in the default slot. Omit to use the default slot instead — the two are mutually exclusive per instance. */

--- a/packages/ui/src/components/BreadcrumbSeparator/BreadcrumbSeparator.vue
+++ b/packages/ui/src/components/BreadcrumbSeparator/BreadcrumbSeparator.vue
@@ -1,5 +1,5 @@
 <template>
-  <li ref="root" aria-hidden="true" :class="rootPart.class" :style="rootPart.style">
+  <li ref="root" v-bind="attrs" aria-hidden="true" :class="rootPart.class" :style="rootPart.style">
     <slot>
       <svg viewBox="0 0 16 16" width="14" height="14" fill="none">
         <path
@@ -17,11 +17,14 @@
 <script setup lang="ts">
 import './BreadcrumbSeparator.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = defineProps<{
   ui?: Partial<{ root: UiPartValue }>
 }>()

--- a/packages/ui/src/components/ButtonGroup/ButtonGroup.vue
+++ b/packages/ui/src/components/ButtonGroup/ButtonGroup.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     role="group"
     :aria-label="ariaLabel"
     :class="rootPart.class"
@@ -13,11 +14,14 @@
 <script setup lang="ts">
 import './ButtonGroup.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     orientation?: 'horizontal' | 'vertical'

--- a/packages/ui/src/components/Card/Card.vue
+++ b/packages/ui/src/components/Card/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="as" ref="root" :class="rootPart.class" :style="rootPart.style">
+  <component :is="as" ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
     <header v-if="title || $slots.header" :class="headerPart.class" :style="headerPart.style">
       <slot name="header">
         <h3 v-if="title" :class="titlePart.class" :style="titlePart.style">{{ title }}</h3>
@@ -17,15 +17,18 @@
   </component>
 </template>
 
-<!-- Part naming mirrors Dialog for muscle memory; root attrs fall through (no click interception) -->
+<!-- Part naming mirrors Dialog for muscle memory -->
 <script setup lang="ts">
 import './Card.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     /** Default header title; ignored when `#header` is used. */

--- a/packages/ui/src/components/Checkbox/Checkbox.vue
+++ b/packages/ui/src/components/Checkbox/Checkbox.vue
@@ -1,6 +1,7 @@
 <template>
   <label
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
@@ -61,12 +62,23 @@
 <script setup lang="ts">
 import './Checkbox.css'
 import '../shared/tokens.css'
-import { computed, nextTick, onMounted, shallowRef, useTemplateRef, watchEffect } from 'vue'
+import {
+  computed,
+  nextTick,
+  onMounted,
+  shallowRef,
+  useAttrs,
+  useTemplateRef,
+  watchEffect,
+} from 'vue'
 import { useFieldControl } from '../../composables/useFieldControl'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 /** Checked state. Bind an array instead to toggle this checkbox's `value` prop in/out of it (checkbox-group pattern). */
 const modelValue = defineModel<boolean | unknown[]>({ default: false })
 

--- a/packages/ui/src/components/Chip/Chip.vue
+++ b/packages/ui/src/components/Chip/Chip.vue
@@ -1,6 +1,7 @@
 <template>
   <span
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-disabled="disabled || undefined"
@@ -35,12 +36,15 @@
 import './Chip.css'
 import '../shared/tokens.css'
 import '../shared/chip.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 import { useUiMessages } from '../../messages'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     label?: string

--- a/packages/ui/src/components/Collapsible/Collapsible.vue
+++ b/packages/ui/src/components/Collapsible/Collapsible.vue
@@ -1,5 +1,11 @@
 <template>
-  <div ref="root" :class="rootPart.class" :style="rootPart.style" :data-state="dataState">
+  <div
+    ref="root"
+    v-bind="attrs"
+    :class="rootPart.class"
+    :style="rootPart.style"
+    :data-state="dataState"
+  >
     <span
       ref="triggerWrapper"
       :class="triggerPart.class"
@@ -28,12 +34,15 @@
 <script setup lang="ts">
 import './Collapsible.css'
 import '../shared/tokens.css'
-import { computed, useId, useTemplateRef, watchEffect } from 'vue'
+import { computed, useAttrs, useId, useTemplateRef, watchEffect } from 'vue'
 import { useCollapse } from '../../composables/useCollapse'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const open = defineModel<boolean>('open', { default: false })
 
 const props = withDefaults(

--- a/packages/ui/src/components/DataTable/DataTable.vue
+++ b/packages/ui/src/components/DataTable/DataTable.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     class="ui-datatable"
     :class="rootClasses"
     :data-stacked="stacked ? '' : undefined"
@@ -9,11 +10,6 @@
       <slot name="toolbar" :selected="selected" :count="sortedData.length" />
     </div>
 
-    <!-- `scrollHeight` splits the header into its own non-scrolling table
-         above a separately `overflow-y:auto` body table, so the scrollbar's
-         track starts at the body — a single sticky-<th> container still
-         spans the header in its scrollable box. Both tables share one
-         horizontally-scrolling parent, so no JS scroll-sync is needed. -->
     <div class="ui-datatable-scroll-x">
       <template v-if="scrollHeight">
         <table
@@ -91,6 +87,7 @@ import {
   onUpdated,
   provide,
   ref,
+  useAttrs,
   useId,
   useSlots,
   useTemplateRef,
@@ -108,6 +105,9 @@ import DataTableHead from './DataTableHead.vue'
 import DataTableBody from './DataTableBody.vue'
 import type { TableRowEntry } from './DataTableBody.vue'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     data: T[]

--- a/packages/ui/src/components/Dial/Dial.vue
+++ b/packages/ui/src/components/Dial/Dial.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="[dialRootStyle, rootPart.style]"
     :data-dragging="isDragging || undefined"
@@ -112,13 +113,16 @@ export const DIAL_TICKS = Array.from({ length: DIAL_TICK_COUNT }, (_, i) => {
 <script setup lang="ts">
 import './Dial.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useFieldControl } from '../../composables/useFieldControl'
 import { useDial } from '../../composables/useDial'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const modelValue = defineModel<number>({ default: 0 })
 
 const props = withDefaults(

--- a/packages/ui/src/components/Dock/Dock.vue
+++ b/packages/ui/src/components/Dock/Dock.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="rootEl"
+    v-bind="attrs"
     role="toolbar"
     :aria-orientation="orientation === 'vertical' ? 'vertical' : undefined"
     :class="rootPart.class"
@@ -41,7 +42,7 @@
 <script setup lang="ts">
 import './Dock.css'
 import '../shared/tokens.css'
-import { computed, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, shallowRef, useAttrs, useTemplateRef, watch } from 'vue'
 import type { Component } from 'vue'
 import type { Side } from '@floating-ui/dom'
 import { useDock } from '../../composables/useDock'
@@ -50,6 +51,10 @@ import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 import { vTooltip } from '../../directives/vTooltip'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 /**
  * One dock item. Deliberately compatible with `MenuItemData`'s established

--- a/packages/ui/src/components/Kbd/Kbd.vue
+++ b/packages/ui/src/components/Kbd/Kbd.vue
@@ -1,5 +1,5 @@
 <template>
-  <kbd ref="root" :class="rootPart.class" :style="rootPart.style"><slot /></kbd>
+  <kbd ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style"><slot /></kbd>
 </template>
 
 <!--
@@ -13,11 +13,14 @@
 <script setup lang="ts">
 import './Kbd.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     ui?: Partial<{ root: UiPartValue }>

--- a/packages/ui/src/components/Knob/Knob.vue
+++ b/packages/ui/src/components/Knob/Knob.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="[knobStyle, rootPart.style]"
     :data-dragging="isDragging || undefined"
@@ -45,8 +46,6 @@
   </div>
 </template>
 
-<!-- Rotary value input: direct manipulation via pointer angle, no live-drag transitions, custom properties for CSS -->
-
 <script lang="ts">
 // Fixed 100x100 viewBox + pathLength="100" for simple 0-100 scale on stroke-dashoffset
 function polarPoint(cx: number, cy: number, r: number, deg: number): { x: number; y: number } {
@@ -65,13 +64,16 @@ export const KNOB_ARC_PATH = `M ${start.x.toFixed(3)} ${start.y.toFixed(3)} A ${
 <script setup lang="ts">
 import './Knob.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useFieldControl } from '../../composables/useFieldControl'
 import { useKnob } from '../../composables/useKnob'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const modelValue = defineModel<number>({ default: 0 })
 
 const props = withDefaults(

--- a/packages/ui/src/components/Loader/Loader.vue
+++ b/packages/ui/src/components/Loader/Loader.vue
@@ -1,6 +1,7 @@
 <template>
   <span
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="[rootStyle, rootPart.style]"
     :role="label ? 'status' : undefined"
@@ -16,11 +17,14 @@
 import './Loader.css'
 import '../shared/tokens.css'
 import '../shared/loader-spinner.css'
-import { computed, useId, useTemplateRef } from 'vue'
+import { computed, useAttrs, useId, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = defineProps<{
   /** Any CSS length. Sets the root's font-size — the ring is sized in `em`, so it scales with it. */
   size?: string

--- a/packages/ui/src/components/MenuList/MenuList.vue
+++ b/packages/ui/src/components/MenuList/MenuList.vue
@@ -1,5 +1,11 @@
 <template>
-  <nav ref="list" :class="rootPart.class" :style="rootPart.style" @keydown="onKeydown">
+  <nav
+    ref="list"
+    v-bind="attrs"
+    :class="rootPart.class"
+    :style="rootPart.style"
+    @keydown="onKeydown"
+  >
     <div
       v-if="hasActiveMatch"
       class="ui-menu-list-indicator"
@@ -83,12 +89,15 @@ export interface MenuListProps<T extends MenuItemData = MenuItemData> {
 <script setup lang="ts" generic="T extends MenuItemData = MenuItemData">
 import './MenuList.css'
 import '../shared/tokens.css'
-import { computed, onMounted, useTemplateRef } from 'vue'
+import { computed, onMounted, useAttrs, useTemplateRef } from 'vue'
 import { useMenu } from '../../composables/useMenu'
 import { useTabIndicator } from '../../composables/useTabIndicator'
 import { useClassMerge, resolveUiPart, splitUiPart } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = defineProps<MenuListProps<T>>()
 
 const emit = defineEmits<{

--- a/packages/ui/src/components/Message/Message.vue
+++ b/packages/ui/src/components/Message/Message.vue
@@ -4,6 +4,7 @@
       v-if="forceMount || open"
       v-show="open"
       ref="root"
+      v-bind="attrs"
       :class="rootPart.class"
       :style="rootPart.style"
       :role="resolvedRole"
@@ -87,11 +88,13 @@ export interface MessageProps {
 <script setup lang="ts">
 import './Message.css'
 import '../shared/tokens.css'
-import { computed, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, shallowRef, useAttrs, useTemplateRef, watch } from 'vue'
 import { useUiMessages } from '../../messages'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import { useThemedUi } from '../../theme'
 import StatusIcon from '../internal/StatusIcon.vue'
+
+defineOptions({ inheritAttrs: false })
 
 const open = defineModel<boolean>('open', { default: true })
 
@@ -118,6 +121,8 @@ defineSlots<{
 
 const messages = useUiMessages()
 const root = useTemplateRef<HTMLElement>('root')
+const rawAttrs = useAttrs()
+const attrs = computed(() => ({ ...rawAttrs }))
 
 const isClosing = shallowRef(false)
 let pendingClose: symbol | null = null

--- a/packages/ui/src/components/OtpInput/OtpInput.vue
+++ b/packages/ui/src/components/OtpInput/OtpInput.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
@@ -65,6 +66,7 @@ import {
   onMounted,
   onScopeDispose,
   shallowRef,
+  useAttrs,
   useSlots,
   useTemplateRef,
   watch,
@@ -75,6 +77,9 @@ import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const modelValue = defineModel<string>({ default: '' })
 
 const props = withDefaults(

--- a/packages/ui/src/components/Pagination/Pagination.vue
+++ b/packages/ui/src/components/Pagination/Pagination.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav :class="rootPart.class" :style="rootPart.style" aria-label="Pagination">
+  <nav v-bind="attrs" :class="rootPart.class" :style="rootPart.style" aria-label="Pagination">
     <ul :class="listPart.class" :style="listPart.style">
       <li>
         <Button
@@ -126,13 +126,17 @@
 <script setup lang="ts">
 import './Pagination.css'
 import '../shared/tokens.css'
-import { computed } from 'vue'
+import { computed, useAttrs } from 'vue'
 import Button from '../Button/Button.vue'
 import Select from '../Select/Select.vue'
 import type { SelectItemData } from '../Select/Select.vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 const page = defineModel<number>('page', { default: 1 })
 const pageSize = defineModel<number>('pageSize', { default: 10 })

--- a/packages/ui/src/components/Progress/Progress.vue
+++ b/packages/ui/src/components/Progress/Progress.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     role="progressbar"
@@ -19,11 +20,14 @@
 <script setup lang="ts">
 import './Progress.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     /** `null`/`undefined` renders the indeterminate (looping) state. */

--- a/packages/ui/src/components/PullToRefresh/PullToRefresh.vue
+++ b/packages/ui/src/components/PullToRefresh/PullToRefresh.vue
@@ -1,5 +1,11 @@
 <template>
-  <div ref="root" :class="rootPart.class" :style="rootPart.style" :data-state="state">
+  <div
+    ref="root"
+    v-bind="attrs"
+    :class="rootPart.class"
+    :style="rootPart.style"
+    :data-state="state"
+  >
     <div
       ref="zoneEl"
       :class="zonePart.class"
@@ -71,12 +77,16 @@ export interface PullToRefreshProps {
 import './PullToRefresh.css'
 import '../shared/tokens.css'
 import '../shared/loader-spinner.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { usePullToRefresh } from '../../composables/usePullToRefresh'
 import type { PullToRefreshState } from '../../composables/usePullToRefresh'
 import { useUiMessages } from '../../messages'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 const props = defineProps<PullToRefreshProps>()
 

--- a/packages/ui/src/components/Radio/Radio.vue
+++ b/packages/ui/src/components/Radio/Radio.vue
@@ -1,5 +1,11 @@
 <template>
-  <label ref="root" :class="rootPart.class" :style="rootPart.style" :data-state="dataState">
+  <label
+    ref="root"
+    v-bind="attrs"
+    :class="rootPart.class"
+    :style="rootPart.style"
+    :data-state="dataState"
+  >
     <span class="ui-radio-frame">
       <input
         ref="inputEl"
@@ -31,12 +37,24 @@
 <script setup lang="ts">
 import './Radio.css'
 import '../shared/tokens.css'
-import { computed, inject, nextTick, onMounted, shallowRef, useId, useTemplateRef } from 'vue'
+import {
+  computed,
+  inject,
+  nextTick,
+  onMounted,
+  shallowRef,
+  useAttrs,
+  useId,
+  useTemplateRef,
+} from 'vue'
 import { radioGroupKey } from '../RadioGroup/RadioGroup.vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = defineProps<{
   value: string | number
   /** Overridden entirely by the `#default` scoped slot. */

--- a/packages/ui/src/components/RadioGroup/RadioGroup.vue
+++ b/packages/ui/src/components/RadioGroup/RadioGroup.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     role="radiogroup"
     :id="fieldControl.id"
     :class="rootPart.class"
@@ -34,11 +35,15 @@ export const radioGroupKey: InjectionKey<RadioGroupContext> = Symbol('ui-radio-g
 <script setup lang="ts">
 import './RadioGroup.css'
 import '../shared/tokens.css'
-import { computed, provide, useId, useTemplateRef } from 'vue'
+import { computed, provide, useAttrs, useId, useTemplateRef } from 'vue'
 import { useFieldControl } from '../../composables/useFieldControl'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 const modelValue = defineModel<string | number | null>({ default: null })
 

--- a/packages/ui/src/components/Resizable/Resizable.vue
+++ b/packages/ui/src/components/Resizable/Resizable.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="[sizeStyle, rootPart.style]"
     :data-resizing="isDragging || undefined"
@@ -33,12 +34,16 @@
 <script setup lang="ts">
 import './Resizable.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useResizable } from '../../composables/useResizable'
 import type { ResizeDirection, ResizeEdge } from '../../composables/useResizable'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 const modelValue = defineModel<number>('size', { required: true })
 

--- a/packages/ui/src/components/ScrollArea/ScrollArea.vue
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="root" :class="rootPart.class" :style="rootPart.style">
+  <div ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
     <div
       ref="viewport"
       :class="viewportPart.class"
@@ -15,12 +15,15 @@
 <script setup lang="ts">
 import './ScrollArea.css'
 import '../shared/tokens.css'
-import { computed, onBeforeUnmount, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onBeforeUnmount, shallowRef, useAttrs, useTemplateRef, watch } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 import { vScrollMask } from '../../directives/vScrollMask'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     orientation?: 'vertical' | 'horizontal' | 'both'

--- a/packages/ui/src/components/SelectButton/SelectButton.vue
+++ b/packages/ui/src/components/SelectButton/SelectButton.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :role="multiple ? 'group' : 'radiogroup'"
     :id="fieldControl.id"
     :class="rootPart.class"
@@ -54,12 +55,16 @@ export interface SelectButtonItem {
 <script setup lang="ts" generic="T extends SelectButtonItem = SelectButtonItem">
 import './SelectButton.css'
 import '../shared/tokens.css'
-import { computed, useId, useTemplateRef } from 'vue'
+import { computed, useAttrs, useId, useTemplateRef } from 'vue'
 import { useTabIndicator } from '../../composables/useTabIndicator'
 import { useFieldControl } from '../../composables/useFieldControl'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 const modelValue = defineModel<string | number | (string | number)[] | null>({ default: null })
 

--- a/packages/ui/src/components/Separator/Separator.vue
+++ b/packages/ui/src/components/Separator/Separator.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     role="separator"
@@ -25,11 +26,14 @@
 <script setup lang="ts">
 import './Separator.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const root = useTemplateRef<HTMLElement>('root')
 
 const props = withDefaults(

--- a/packages/ui/src/components/Skeleton/Skeleton.vue
+++ b/packages/ui/src/components/Skeleton/Skeleton.vue
@@ -1,18 +1,26 @@
 <template>
-  <span ref="root" :class="rootPart.class" :style="rootPart.style" aria-hidden="true">
+  <span
+    ref="root"
+    v-bind="attrs"
+    :class="rootPart.class"
+    :style="rootPart.style"
+    aria-hidden="true"
+  >
     <span v-if="$slots.default" class="ui-skeleton-content"><slot /></span>
   </span>
 </template>
 
-<!-- Slotted content (visibility: hidden) sizes skeleton; no ARIA role (consumer pairs with live region). -->
 <script setup lang="ts">
 import './Skeleton.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     /** `text` (default): 1em-tall rounded line. `circle`: round, aspect-ratio 1. `rect`: `--ui-radius` corners, sized by content or `ui.root`. */

--- a/packages/ui/src/components/Slider/Slider.vue
+++ b/packages/ui/src/components/Slider/Slider.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="[sliderStyle, rootPart.style]"
     :data-dragging="isDragging || undefined"
@@ -56,13 +57,16 @@
 <script setup lang="ts">
 import './Slider.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useFieldControl } from '../../composables/useFieldControl'
 import { useSlider } from '../../composables/useSlider'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const modelValue = defineModel<number | [number, number]>({ default: 0 })
 
 const props = withDefaults(

--- a/packages/ui/src/components/SwipeToReveal/SwipeToReveal.vue
+++ b/packages/ui/src/components/SwipeToReveal/SwipeToReveal.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-side="side"
@@ -26,7 +27,7 @@
 <script setup lang="ts">
 import './SwipeToReveal.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useElementSize } from '@vueuse/core'
 import { useSwipeReveal } from '../../composables/useSwipeReveal'
 import type { SwipeRevealSide } from '../../composables/useSwipeReveal'
@@ -34,6 +35,9 @@ import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const open = defineModel<boolean>('open', { default: false })
 
 const props = withDefaults(

--- a/packages/ui/src/components/Switch/Switch.vue
+++ b/packages/ui/src/components/Switch/Switch.vue
@@ -1,6 +1,7 @@
 <template>
   <label
     ref="root"
+    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
@@ -38,11 +39,15 @@
 <script setup lang="ts">
 import './Switch.css'
 import '../shared/tokens.css'
-import { computed, nextTick, onMounted, shallowRef, useTemplateRef } from 'vue'
+import { computed, nextTick, onMounted, shallowRef, useAttrs, useTemplateRef } from 'vue'
 import { useFieldControl } from '../../composables/useFieldControl'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 const modelValue = defineModel<boolean>({ default: false })
 

--- a/packages/ui/src/components/Tabs/Tabs.vue
+++ b/packages/ui/src/components/Tabs/Tabs.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="list"
+    v-bind="attrs"
     role="tablist"
     :aria-orientation="props.orientation === 'vertical' ? 'vertical' : undefined"
     :class="listPart.class"
@@ -14,11 +15,15 @@
 <script setup lang="ts" generic="T extends string">
 import './Tabs.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useTabs } from '../../composables/useTabs'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 
 const active = defineModel<T>('active', { required: true })
 

--- a/packages/ui/src/components/Tag/Tag.vue
+++ b/packages/ui/src/components/Tag/Tag.vue
@@ -1,5 +1,5 @@
 <template>
-  <span ref="root" :class="rootPart.class" :style="rootPart.style">
+  <span ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
     <span v-if="$slots.icon" class="ui-tag-icon" aria-hidden="true"><slot name="icon" /></span>
     <span class="ui-tag-label"><slot /></span>
   </span>
@@ -9,11 +9,14 @@
 <script setup lang="ts">
 import './Tag.css'
 import '../shared/tokens.css'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useAttrs, useTemplateRef } from 'vue'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 const props = withDefaults(
   defineProps<{
     variant?: 'primary' | 'muted' | 'success' | 'warning' | 'danger' | 'info'

--- a/packages/ui/src/components/Toolbar/Toolbar.vue
+++ b/packages/ui/src/components/Toolbar/Toolbar.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="list"
+    v-bind="attrs"
     role="toolbar"
     :aria-orientation="orientation === 'vertical' ? 'vertical' : undefined"
     :class="rootPart.class"
@@ -37,11 +38,15 @@
 <script setup lang="ts">
 import './Toolbar.css'
 import '../shared/tokens.css'
-import { computed, useSlots, useTemplateRef } from 'vue'
+import { computed, useAttrs, useSlots, useTemplateRef } from 'vue'
 import { useToolbar } from '../../composables/useToolbar'
 import { useClassMerge, resolveUiPart } from '../../classes'
 import type { UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
 import Menu from '../Menu/Menu.vue'
 import type { MenuItemData } from '../Menu/Menu.vue'
 

--- a/packages/ui/tests/presence-spike.test.ts
+++ b/packages/ui/tests/presence-spike.test.ts
@@ -3,15 +3,18 @@
  * sentinels):
  *
  * motion-v's AnimatePresence is Vue's <Transition>/<TransitionGroup> with JS
- * hooks. Vue transitions cannot animate a child whose root node is a
- * <Teleport>, so exit-detection does NOT defer DOM removal through Dialog's
- * Teleport boundary — the subtree is yanked synchronously and `exit` never
- * runs. The supported motion path for Dialog exits is therefore the
- * imperative fallback: `force-mount` + `beforeClose(done)` driving
- * panelEl.animate()/GSAP/motion's animate().
+ * hooks. As of Vue 3.6.0-rc.3, exit-detection now correctly defers DOM
+ * removal through a Teleport boundary when the Teleport sits one level
+ * inside a component (test 3: AnimatePresence -> Dialog -> internal
+ * Teleport) — previously yanked synchronously with `exit` never running.
+ * A raw `<Teleport>` as AnimatePresence's own *direct* child (test 2) is
+ * still broken; that's a different code path and wasn't part of this fix.
+ * The imperative fallback (`force-mount` + `beforeClose(done)` driving
+ * panelEl.animate()/GSAP/motion's animate()) therefore remains necessary
+ * for the direct-Teleport-child shape, but the AnimatePresence pattern is
+ * viable again for a real Dialog.
  *
- * If test 2 ever starts failing, motion-v (or Vue) fixed the interop —
- * update the README and prefer the AnimatePresence pattern again.
+ * If test 2 ever starts failing too, update the README further.
  */
 import '../src/style.css'
 import { expect, test, vi } from 'vitest'
@@ -50,16 +53,17 @@ test('KNOWN BROKEN: exit deferral does not cross a Teleport boundary', async () 
   await expect.element(screen.getByTestId('exits')).toHaveTextContent('0')
 })
 
-test('KNOWN BROKEN: same failure with the full force-mounted Dialog', async () => {
+test("FIXED (3.6.0-rc.3): AnimatePresence defers removal through Dialog's internal Teleport", async () => {
   const screen = render(PresenceFixture, realTransitions)
   await screen.getByTestId('open').click()
   const content = () => document.querySelector('[data-testid="motion-content"]')
   await vi.waitFor(() => expect(content()).not.toBeNull())
 
   await screen.getByTestId('dismiss').click()
-  expect(content()).toBeNull()
-  await new Promise((r) => setTimeout(r, 100))
-  await expect.element(screen.getByTestId('exits')).toHaveTextContent('0')
+  expect(content()).not.toBeNull() // still present: exit is running
+
+  await vi.waitFor(() => expect(content()).toBeNull(), { timeout: 3000 })
+  await expect.element(screen.getByTestId('exits')).toHaveTextContent('1')
 })
 
 test('fallback: force-mount + beforeClose defers close for an imperative exit', async () => {

--- a/packages/vapor-ui/package.json
+++ b/packages/vapor-ui/package.json
@@ -13,7 +13,7 @@
     "@floating-ui/dom": "^1.8.0",
     "@vueuse/core": "^14.4.0",
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.2"
+    "vue": "3.6.0-rc.3"
   },
   "devDependencies": {
     "@tsdown/css": "^0.22.14",

--- a/packages/vapor-ui/tests/class-merge.test.ts
+++ b/packages/vapor-ui/tests/class-merge.test.ts
@@ -1,0 +1,55 @@
+/**
+ * REGRESSION SENTINEL — Vapor-only bug: a component whose root wraps its
+ * content in <Transition> auto-forwards its own received attrs (including
+ * `class`) onto VaporTransition as a single-root child, gated on
+ * VaporTransition's own `inheritAttrs` (which it never opts out of) — NOT on
+ * the component's own `inheritAttrs: false`. VaporTransition then applies
+ * those raw attrs directly onto its resolved child via a single-source
+ * `setDynamicProps(el, [attrs])`, unconditionally overwriting whatever the
+ * child's own template computed for `class`. No in-component workaround
+ * exists (tried: implicit fallthrough, explicit v-bind, array :class,
+ * isolated computed — all fail identically). Traced against vue 3.6.0-rc.3
+ * runtime-vapor source (createComponent's isSingleRoot check, ~line 2950;
+ * handleSetupResult's fallthrough trigger, ~line 3457; applyFallthroughProps
+ * -> setDynamicProps, ~line 3073).
+ *
+ * Every other component (no <Transition> in its own template) correctly
+ * merges an external class via `inheritAttrs: false` + `useAttrs()` +
+ * `v-bind="attrs"` on its root — see Button.vue's own established pattern,
+ * applied to 36 components that were missing it.
+ *
+ * If the "Message" test below ever starts passing, the upstream Vue/Vapor
+ * bug got fixed — the `v-bind="attrs"` pattern stays correct either way, so
+ * nothing needs to change in the library itself, just this comment.
+ */
+import { expect, test } from 'vitest'
+import { createVaporApp } from 'vue'
+import ClassMergeButtonRoot from './fixtures/ClassMergeButtonRoot.vue'
+import ClassMergeMessageRoot from './fixtures/ClassMergeMessageRoot.vue'
+
+test('external class merges correctly (no Transition in the component root)', () => {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const app = createVaporApp(ClassMergeButtonRoot)
+  app.mount(host)
+  try {
+    const el = host.querySelector<HTMLElement>('[data-testid="target"]')!
+    expect(el.className).toContain('ui-button')
+    expect(el.className).toContain('external-class')
+  } finally {
+    app.unmount()
+  }
+})
+
+test('KNOWN BROKEN (upstream vue/vapor): external class does not merge through a Transition-wrapped root', () => {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const app = createVaporApp(ClassMergeMessageRoot)
+  app.mount(host)
+  try {
+    const el = host.querySelector<HTMLElement>('[data-testid="target"]')!
+    expect(el.className).toBe('external-class') // should be 'ui-message ui-message--warning external-class'
+  } finally {
+    app.unmount()
+  }
+})

--- a/packages/vapor-ui/tests/fixtures/ClassMergeButtonRoot.vue
+++ b/packages/vapor-ui/tests/fixtures/ClassMergeButtonRoot.vue
@@ -1,0 +1,7 @@
+<template>
+  <Button data-testid="target" class="external-class">Click</Button>
+</template>
+
+<script setup lang="ts" vapor>
+import { Button } from 'vael-ui/vapor'
+</script>

--- a/packages/vapor-ui/tests/fixtures/ClassMergeMessageRoot.vue
+++ b/packages/vapor-ui/tests/fixtures/ClassMergeMessageRoot.vue
@@ -1,0 +1,7 @@
+<template>
+  <Message data-testid="target" variant="warning" title="Test" class="external-class">Body</Message>
+</template>
+
+<script setup lang="ts" vapor>
+import { Message } from 'vael-ui/vapor'
+</script>

--- a/playground/nuxt/package.json
+++ b/playground/nuxt/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.2"
+    "vue": "3.6.0-rc.3"
   },
   "devDependencies": {
     "nuxt": "^4.5.2"

--- a/playground/vapor-interop/package.json
+++ b/playground/vapor-interop/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.2"
+    "vue": "3.6.0-rc.3"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.8",

--- a/playground/vapor/package.json
+++ b/playground/vapor/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.2"
+    "vue": "3.6.0-rc.3"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.8",

--- a/playground/vdom/package.json
+++ b/playground/vdom/package.json
@@ -13,7 +13,7 @@
     "gsap": "^3.15.0",
     "motion-v": "^2.3.0",
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.2",
+    "vue": "3.6.0-rc.3",
     "vue-i18n": "^11.4.8",
     "vue-router": "^5.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   brace-expansion: '>=5.0.8'
+  vue: 3.6.0-rc.3
 
 importers:
 
@@ -55,19 +56,19 @@ importers:
         version: 5.3.0
       '@phosphor-icons/vue':
         specifier: ^2.2.1
-        version: 2.2.1(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 2.2.1(vue@3.6.0-rc.3(typescript@6.0.3))
       '@unhead/vue':
         specifier: ^2.1.17
-        version: 2.1.17(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 2.1.17(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vueuse/core':
         specifier: ^14.4.0
-        version: 14.4.0(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 14.4.0(vue@3.6.0-rc.3(typescript@6.0.3))
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
       motion-v:
         specifier: ^2.3.0
-        version: 2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.2(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.3(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.3(typescript@6.0.3))
       shiki:
         specifier: ^4.4.2
         version: 4.4.2
@@ -76,23 +77,23 @@ importers:
         version: link:../packages/ui
       vee-validate:
         specifier: ^4.15.1
-        version: 4.15.1(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 4.15.1(vue@3.6.0-rc.3(typescript@6.0.3))
       vite-ssg:
         specifier: ^28.3.0
-        version: 28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3)))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3)))(vue@3.6.0-rc.3(typescript@6.0.3))
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.3
+        version: 3.6.0-rc.3(typescript@6.0.3)
       vue-i18n:
         specifier: ^11.4.8
-        version: 11.4.8(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 11.4.8(vue@3.6.0-rc.3(typescript@6.0.3))
       vue-router:
         specifier: ^5.2.0
-        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       beasties:
         specifier: ^0.4.3
         version: 0.4.3
@@ -119,7 +120,7 @@ importers:
         version: 1.8.0
       '@vueuse/core':
         specifier: ^14.4.0
-        version: 14.4.0(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 14.4.0(vue@3.6.0-rc.3(typescript@6.0.3))
     devDependencies:
       '@nuxt/kit':
         specifier: ^4.5.2
@@ -129,13 +130,13 @@ importers:
         version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(yaml@2.9.0)
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vitest@4.1.10)
       motion-v:
         specifier: ^2.3.0
-        version: 2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.2(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.3(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.3(typescript@6.0.3))
       playwright:
         specifier: ^1.62.1
         version: 1.62.1
@@ -147,7 +148,7 @@ importers:
         version: 6.0.3
       unplugin-vue:
         specifier: ^7.2.0
-        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.3)(rollup@4.62.4)(terser@5.49.2)(vue@3.6.0-rc.2(typescript@6.0.3))(yaml@2.9.0)
+        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.3)(rollup@4.62.4)(terser@5.49.2)(vue@3.6.0-rc.3(typescript@6.0.3))(yaml@2.9.0)
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
@@ -156,10 +157,10 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0(supports-color@10.2.2))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       vitest-browser-vue:
         specifier: ^2.1.0
-        version: 2.1.0(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 2.1.0(@vue/compiler-dom@3.6.0-rc.3)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.3(typescript@6.0.3))
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.3
+        version: 3.6.0-rc.3(typescript@6.0.3)
       vue-component-type-helpers:
         specifier: ^3.3.9
         version: 3.3.9
@@ -174,20 +175,20 @@ importers:
         version: 1.8.0
       '@vueuse/core':
         specifier: ^14.4.0
-        version: 14.4.0(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 14.4.0(vue@3.6.0-rc.3(typescript@6.0.3))
       vael-ui:
         specifier: workspace:*
         version: link:../ui
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.3
+        version: 3.6.0-rc.3(typescript@6.0.3)
     devDependencies:
       '@tsdown/css':
         specifier: ^0.22.14
         version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(yaml@2.9.0)
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vitest@4.1.10)
@@ -202,7 +203,7 @@ importers:
         version: 6.0.3
       unplugin-vue:
         specifier: ^7.2.0
-        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.3)(rollup@4.62.4)(terser@5.49.2)(vue@3.6.0-rc.2(typescript@6.0.3))(yaml@2.9.0)
+        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.3)(rollup@4.62.4)(terser@5.49.2)(vue@3.6.0-rc.3(typescript@6.0.3))(yaml@2.9.0)
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
@@ -219,8 +220,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.3
+        version: 3.6.0-rc.3(typescript@6.0.3)
     devDependencies:
       nuxt:
         specifier: ^4.5.2
@@ -232,12 +233,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.3
+        version: 3.6.0-rc.3(typescript@6.0.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -254,12 +255,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.3
+        version: 3.6.0-rc.3(typescript@6.0.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vitest@4.1.10)
@@ -283,35 +284,35 @@ importers:
     dependencies:
       '@phosphor-icons/vue':
         specifier: ^2.2.1
-        version: 2.2.1(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 2.2.1(vue@3.6.0-rc.3(typescript@6.0.3))
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
       motion-v:
         specifier: ^2.3.0
-        version: 2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.2(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.3(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.3(typescript@6.0.3))
       vael-ui:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.2
-        version: 3.6.0-rc.2(typescript@6.0.3)
+        specifier: 3.6.0-rc.3
+        version: 3.6.0-rc.3(typescript@6.0.3)
       vue-i18n:
         specifier: ^11.4.8
-        version: 11.4.8(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 11.4.8(vue@3.6.0-rc.3(typescript@6.0.3))
       vue-router:
         specifier: ^5.2.0
-        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vee-validate:
         specifier: ^4.15.1
-        version: 4.15.1(vue@3.6.0-rc.2(typescript@6.0.3))
+        version: 4.15.1(vue@3.6.0-rc.3(typescript@6.0.3))
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
@@ -1098,7 +1099,7 @@ packages:
       nuxt: 4.5.2
       rolldown: ^1.0.0
       rollup-plugin-visualizer: ^6.0.0 || ^7.0.1
-      vue: ^3.3.4
+      vue: 3.6.0-rc.3
     peerDependenciesMeta:
       '@babel/plugin-proposal-decorators':
         optional: true
@@ -1369,7 +1370,7 @@ packages:
     resolution: {integrity: sha512-3RNg1utc2Z5RwPKWFkW3eXI/0BfQAwXgtFxPUPeSzi55jGYUq16b+UqcgbKLazWFlwg5R92OCLKjDiJjeiJcnA==}
     engines: {node: '>=14'}
     peerDependencies:
-      vue: '>=3.2.39'
+      vue: 3.6.0-rc.3
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1913,13 +1914,13 @@ packages:
   '@unhead/vue@2.1.17':
     resolution: {integrity: sha512-pnC8x9HLV3qQXdvWfylUEU25uhfCAy3ly9nmpQz84j9py818DRfU8jOsQ5wjdWtxyU1vX/fW2udfm4jtxUK8Bg==}
     peerDependencies:
-      vue: '>=3.5.18'
+      vue: 3.6.0-rc.3
 
   '@unhead/vue@3.3.1':
     resolution: {integrity: sha512-iS+eiE1NehbV/eF7wzR7UUuUVTv8fIphFOCekQvEMuPqfKPCB8f3wf7sgPgUngYX6mdgM6PmkGmaOQgTBxqwbw==}
     peerDependencies:
       vite: '>=6.4.2'
-      vue: '>=3.5.18'
+      vue: 3.6.0-rc.3
       webpack: '>=5.0.0'
     peerDependenciesMeta:
       vite:
@@ -1937,14 +1938,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      vue: ^3.0.0
+      vue: 3.6.0-rc.3
 
   '@vitejs/plugin-vue@6.0.8':
     resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      vue: ^3.2.25
+      vue: 3.6.0-rc.3
 
   '@vitest/browser-playwright@4.1.10':
     resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
@@ -1999,7 +2000,7 @@ packages:
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      vue: ^2.7.0 || ^3.2.25
+      vue: 3.6.0-rc.3
     peerDependenciesMeta:
       vue:
         optional: true
@@ -2023,29 +2024,29 @@ packages:
   '@vue/compiler-core@3.5.40':
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
 
-  '@vue/compiler-core@3.6.0-rc.2':
-    resolution: {integrity: sha512-Xx79h4EpJktQBShelXNKaRuvn9N6YsYL1j+RXdvPKzI+8tohYziBJbxOFGAkdcOKBwKc2SIWV4DOlTAMhE96yQ==}
+  '@vue/compiler-core@3.6.0-rc.3':
+    resolution: {integrity: sha512-WtpFH7AYGbw7K1AbUKkLxYRfrp0+0kB5RHMlEeTk5sKGcwSV+sNZQbq7R3Ybaq55XLjPCd0QF7TG3AQauGoIiQ==}
 
   '@vue/compiler-dom@3.5.40':
     resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
 
-  '@vue/compiler-dom@3.6.0-rc.2':
-    resolution: {integrity: sha512-dRTdTdi/KXzHYIkHtyjGxepTIxnsZ/hB3v1osnS8c4MeycAyzkSoZW6OZkXXN4oVVVU6NKXds1XtKAEKVVw7nA==}
+  '@vue/compiler-dom@3.6.0-rc.3':
+    resolution: {integrity: sha512-n/3HTAcXwNdwrx8eS1JUwCw4wbS+gPi8hIM7WcoTvHqgYJL5xhfChsmJQtzkX24Lweu7strPsNSbNsf/S3D3WQ==}
 
   '@vue/compiler-sfc@3.5.40':
     resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
 
-  '@vue/compiler-sfc@3.6.0-rc.2':
-    resolution: {integrity: sha512-EZWTNh0UwdxvrBJkFc6+dqfwuUSdTVHDIohQcGDPCqGaYTHOfUL20b+grEAzlyxB741KrVBUb7qqpes92hAh2w==}
+  '@vue/compiler-sfc@3.6.0-rc.3':
+    resolution: {integrity: sha512-+QT0wGQixwrkvG+qGEY2SkzUJJw1M3KlXtJ+xFHeZXZrPmvLWVAt/4B/G/H0gVWa8SiqOZLedI7ADqmjgm7Q6Q==}
 
   '@vue/compiler-ssr@3.5.40':
     resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
 
-  '@vue/compiler-ssr@3.6.0-rc.2':
-    resolution: {integrity: sha512-lqHSdQTmlhKX3dNEvR1TcspUzDlTR82T7BYLDzfvTwAqGXxAI2WJfyGJPcNpPjPKYEMI9JRGF32DU8TlHLx1AA==}
+  '@vue/compiler-ssr@3.6.0-rc.3':
+    resolution: {integrity: sha512-iywY3ipWer9pJ6Xa5vQ1sGd/hT0cGPDn7m5zwJDKnBcflSt4pfktE+xl2t0cSFs4/mTHEevuz5xamdyCJ2L6KQ==}
 
-  '@vue/compiler-vapor@3.6.0-rc.2':
-    resolution: {integrity: sha512-QbrA01pbj9xemF2McgBopyaOwj3kQGN0W1GW5EdFXORIT4fQQJpmUOj40h99S3bk09gLs5bFTRS4YE+Oyw/F9w==}
+  '@vue/compiler-vapor@3.6.0-rc.3':
+    resolution: {integrity: sha512-wMdb1WpwosxWl3sNOYLPw9DgL+AzSdaJWnBi5GEvR1ajqb7mY3Ivenvs5QIBGXRbNYKrQBqfdkBWH/3xNWIXwQ==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -2059,7 +2060,7 @@ packages:
   '@vue/devtools-core@8.2.1':
     resolution: {integrity: sha512-s/VfAY9oDTb/kFEWmy461jaFde2MIV1RO/gi1vwM+PAZBZ/Pc2Ndu3BNBdZUze8QDUuyYvElbEEGA83syjJfzA==}
     peerDependencies:
-      vue: ^3.0.0
+      vue: 3.6.0-rc.3
 
   '@vue/devtools-kit@7.7.10':
     resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
@@ -2082,31 +2083,31 @@ packages:
   '@vue/reactivity@3.5.41':
     resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
 
-  '@vue/reactivity@3.6.0-rc.2':
-    resolution: {integrity: sha512-B01EoSTcaVQiJwZDoSoeKYClVgj60BHN43oHEcxXhPVLdxsXI0SOiQuskUskQDZn2ma08llICKJohL60o+UamA==}
+  '@vue/reactivity@3.6.0-rc.3':
+    resolution: {integrity: sha512-+Uvp1i+oozwkyVy2HGUhmA23QDO/YY+QyBm32oddZyG6+FEaEANG7NCQr+asSJzNHWAZmZo97zVNai0tOBdJRw==}
 
   '@vue/runtime-core@3.5.40':
     resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
 
-  '@vue/runtime-core@3.6.0-rc.2':
-    resolution: {integrity: sha512-qFV61Hbg6LyEGxJiVRJYuiIfryxrfO4+cgW1esxtkR1/pvemULwG6KpFImsJDwcC+YxrtvndXGM5PRVwUCGuiA==}
+  '@vue/runtime-core@3.6.0-rc.3':
+    resolution: {integrity: sha512-uGD8nlft/+wKALxpSDzItg1ICtNMQkkOjCurmG9evTVgerBmkm0RUmZGHlIaKVECLizKBpf7s+p0NaH9yZJfLA==}
 
   '@vue/runtime-dom@3.5.40':
     resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
 
-  '@vue/runtime-dom@3.6.0-rc.2':
-    resolution: {integrity: sha512-clIE/xk0b61t30BPKoOXZep253nhWdjyw7iac53yy2KN0nxAupkb6x3ImOI9iljjXqOW5lYdNVHNxNlcx3iA1Q==}
+  '@vue/runtime-dom@3.6.0-rc.3':
+    resolution: {integrity: sha512-/cB2vZhcGFhl+YYxwsJyFB1KjVFKK29JATuJzSQxhlXbCD+kAwJ1ZJB615RS9Yd5mC9hooM65G9clrbD9LlXHA==}
 
-  '@vue/runtime-vapor@3.6.0-rc.2':
-    resolution: {integrity: sha512-8EpxbNyT629k/52el4D7PxXmZtiYhJRBHPXJR7CZw0OluiADtT9W8J+XB83EVlzHmFUysXcd+mGWmuHwIhuHZA==}
+  '@vue/runtime-vapor@3.6.0-rc.3':
+    resolution: {integrity: sha512-4OrYk9KWBz71axcmDTPh1TiGG84dq937Olj3qlGp9rklVwUL0f+7w1dZSfWPzV4Y/d8ye6WgLfNmntqBOX094g==}
     peerDependencies:
-      '@vue/runtime-dom': 3.6.0-rc.2
+      '@vue/runtime-dom': 3.6.0-rc.3
 
   '@vue/server-renderer@3.5.40':
     resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
 
-  '@vue/server-renderer@3.6.0-rc.2':
-    resolution: {integrity: sha512-TIsqoYljs6b0wfoCDhv4EeU3Du2a8gTadkaTGMjIYLTLlO4p8r4VdDqfNp/ZMAm87bW4ST1naBMRe+bXQBpAeQ==}
+  '@vue/server-renderer@3.6.0-rc.3':
+    resolution: {integrity: sha512-YCKcCMz7NY92Wp6Ugv7JBFHqgbdteIC6CM3TzMMbJ8uB56sUXrF7qJRh3z6AyH3FESycFdXnUSIwNhkmjL5hfg==}
 
   '@vue/shared@3.5.40':
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
@@ -2114,15 +2115,15 @@ packages:
   '@vue/shared@3.5.41':
     resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
 
-  '@vue/shared@3.6.0-rc.2':
-    resolution: {integrity: sha512-Tz44lKLjxhWRu3GJ38768dc2hW4XhDtTB5aUo5fCMis6YDyFzwQYkrD/B9SuQ1v/ailv6UVR3wSHiujNXSjMCQ==}
+  '@vue/shared@3.6.0-rc.3':
+    resolution: {integrity: sha512-EFnGq/OonnFgOtgAhXLIv8owITuFsaGglKXjsAUJQ+2uVuCPxypdW7NIZUlt7ED2raM1Hn/C83eTeK0tZVGCZw==}
 
   '@vue/test-utils@2.4.11':
     resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
     peerDependencies:
       '@vue/compiler-dom': 3.x
       '@vue/server-renderer': 3.x
-      vue: 3.x
+      vue: 3.6.0-rc.3
     peerDependenciesMeta:
       '@vue/server-renderer':
         optional: true
@@ -2130,7 +2131,7 @@ packages:
   '@vueuse/core@14.4.0':
     resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
     peerDependencies:
-      vue: ^3.5.0
+      vue: 3.6.0-rc.3
 
   '@vueuse/metadata@14.4.0':
     resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
@@ -2138,7 +2139,7 @@ packages:
   '@vueuse/shared@14.4.0':
     resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
     peerDependencies:
-      vue: ^3.5.0
+      vue: 3.6.0-rc.3
 
   '@yuku-codegen/binding-android-arm64@0.8.4':
     resolution: {integrity: sha512-rsYkGl2kOkDRsh1mxriYnk1qBS78vjlBJ3+T2XwtwKwqOliy2n+2Ae0EDxJ/uX1DZLm3KkBZarGO5isEnmHchA==}
@@ -3821,7 +3822,7 @@ packages:
     resolution: {integrity: sha512-J0CCfXtICCni9RjotDUBOs57xNpYI9yyBSohEOxaRHrmjwOtlw291fhRu/mdgEdSasys96R028YDDOAtWBbRaA==}
     peerDependencies:
       '@vueuse/core': '>=10.0.0'
-      vue: '>=3.0.0'
+      vue: 3.6.0-rc.3
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -5033,7 +5034,7 @@ packages:
     resolution: {integrity: sha512-6JHWcRbLO3bySOsipQSW9n2VRoPqsx9GLSWBfp7QLPCvpUr/edeAXR7pSl44EEJ+FIp9bG8Zm+xm5dnM/yir4Q==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      vue: ^3.2.25
+      vue: 3.6.0-rc.3
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -5166,7 +5167,7 @@ packages:
   vee-validate@4.15.1:
     resolution: {integrity: sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==}
     peerDependencies:
-      vue: ^3.4.26
+      vue: 3.6.0-rc.3
 
   verkit@0.3.2:
     resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
@@ -5238,7 +5239,7 @@ packages:
     resolution: {integrity: sha512-0tQCjCqZWVSK6UeRW9S4ABbf47lKQ68zvrT2FNvZmiL+alDydCVyH/T3Jlfbdc3T3C2Iuyyl5aVsMbF8IQIoxA==}
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
-      vue: ^3.5.0
+      vue: 3.6.0-rc.3
 
   vite-ssg-sitemap@0.10.0:
     resolution: {integrity: sha512-OIja4fqUMcvWl5+bxQARe3LgzWTd8U/dWHWgrqiC7vv3AmTn0YnhMNUAimQ0M/0Aa9myEIAGLV0yKlYbKP8BJQ==}
@@ -5251,7 +5252,7 @@ packages:
       beasties: ^0.3.5
       prettier: ^3.3.0
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0-0 || ^8.0.0-0
-      vue: ^3.2.10
+      vue: 3.6.0-rc.3
       vue-router: ^4.0.1 || ^5.0.0-0
     peerDependenciesMeta:
       beasties:
@@ -5308,7 +5309,7 @@ packages:
     resolution: {integrity: sha512-K3H/oxIOY4EjXx2bxwrLsPg4jTMvzpRW6Jb6T8XZRoxUvmDVwGkd8mua130F8GZezE7H5QYoXd/S8hYijw7j5g==}
     peerDependencies:
       vitest: ^4.0.0-0
-      vue: ^3.0.0
+      vue: 3.6.0-rc.3
 
   vitest@4.1.10:
     resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
@@ -5381,7 +5382,7 @@ packages:
     resolution: {integrity: sha512-0ULeHP6Z9CGvAm67S77ZEp41cfGXIREGL8qfhos2BMgcQQewtQcDKuojt6jjasAD/S8GwfTp2ySPmDSpwvrCMQ==}
     engines: {node: '>= 22'}
     peerDependencies:
-      vue: ^3.0.0
+      vue: 3.6.0-rc.3
 
   vue-router@5.2.0:
     resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
@@ -5390,7 +5391,7 @@ packages:
       '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
       pinia: ^3.0.4 || ^4.0.2
       vite: ^7.3.0 || ^8.0.0
-      vue: ^3.5.34 || ^4.0.0
+      vue: 3.6.0-rc.3
     peerDependenciesMeta:
       '@pinia/colada':
         optional: true
@@ -5407,16 +5408,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.40:
-    resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  vue@3.6.0-rc.2:
-    resolution: {integrity: sha512-pBgoISqETcufJ1e92vVW2/D5MEbCm2XHlC/5dq3hWq8s17tx9v5BEdYv4hojJ0yEEDidYxUL7itS+vV32wfZrw==}
+  vue@3.6.0-rc.3:
+    resolution: {integrity: sha512-SsLCdsc8WoOJC1KHsMxvkVFjKmVpurF2DZJSy5A8sOSBR6ar1cQ370j2TBO80MW7ct80aHh0oQWU9BzMo8H9Qg==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -6442,12 +6435,12 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.1.0)(rolldown@1.2.3)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.1.0)(rolldown@1.2.3)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      '@vue/devtools-core': 8.2.1(vue@3.5.40(typescript@6.0.3))
+      '@vue/devtools-core': 8.2.1(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vue/devtools-kit': 8.2.1
       birpc: 4.0.0
       consola: 3.4.2
@@ -6475,7 +6468,7 @@ snapshots:
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       which: 6.0.1
       ws: 8.21.3
     transitivePeerDependencies:
@@ -6571,7 +6564,7 @@ snapshots:
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vue/shared': 3.5.41
       consola: 3.4.2
       defu: 6.1.7
@@ -6595,7 +6588,7 @@ snapshots:
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
     optionalDependencies:
@@ -6671,11 +6664,11 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(8d5dcde6d9ff1f2e7e31b48955dfaa25)':
+  '@nuxt/vite-builder@4.5.2(40b36f2289899658236a1b39fc4ead2b)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       autoprefixer: 10.5.4(postcss@8.5.26)
       consola: 3.4.2
       cssnano: 8.0.4(postcss@8.5.26)
@@ -6702,7 +6695,7 @@ snapshots:
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vite-plugin-checker: 0.14.5(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(optionator@0.9.4)(oxlint@1.77.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
       vue-bundle-renderer: 2.3.2
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
@@ -6857,9 +6850,9 @@ snapshots:
       is-glob: 4.0.3
       picomatch: 4.0.5
 
-  '@phosphor-icons/vue@2.2.1(vue@3.6.0-rc.2(typescript@6.0.3))':
+  '@phosphor-icons/vue@2.2.1(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7288,19 +7281,19 @@ snapshots:
     dependencies:
       unhead: 2.1.17
 
-  '@unhead/vue@2.1.17(vue@3.6.0-rc.2(typescript@6.0.3))':
+  '@unhead/vue@2.1.17(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       hookable: 6.1.1
       unhead: 2.1.17
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
-  '@unhead/vue@3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+  '@unhead/vue@3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       '@unhead/bundler': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       hookable: 6.1.1
       unhead: 3.3.1(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
     optionalDependencies:
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -7336,7 +7329,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+  '@vitejs/plugin-vue-jsx@5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
@@ -7344,21 +7337,15 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-      vue: 3.5.40(typescript@6.0.3)
-
-  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -7443,7 +7430,7 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/common@3.1.4(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/common@3.1.4(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.40
       ast-kit: 2.2.0
@@ -7451,17 +7438,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.2
     optionalDependencies:
-      vue: 3.5.40(typescript@6.0.3)
-
-  '@vue-macros/common@3.1.4(vue@3.6.0-rc.2(typescript@6.0.3))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.40
-      ast-kit: 2.2.0
-      local-pkg: 1.2.1
-      magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.2
-    optionalDependencies:
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
@@ -7500,10 +7477,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-rc.2':
+  '@vue/compiler-core@3.6.0-rc.3':
     dependencies:
       '@babel/parser': 7.29.8
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.3
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -7513,10 +7490,10 @@ snapshots:
       '@vue/compiler-core': 3.5.40
       '@vue/shared': 3.5.40
 
-  '@vue/compiler-dom@3.6.0-rc.2':
+  '@vue/compiler-dom@3.6.0-rc.3':
     dependencies:
-      '@vue/compiler-core': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-core': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
 
   '@vue/compiler-sfc@3.5.40':
     dependencies:
@@ -7530,14 +7507,14 @@ snapshots:
       postcss: 8.5.26
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-rc.2':
+  '@vue/compiler-sfc@3.6.0-rc.3':
     dependencies:
       '@babel/parser': 7.29.8
-      '@vue/compiler-core': 3.6.0-rc.2
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/compiler-ssr': 3.6.0-rc.2
-      '@vue/compiler-vapor': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-core': 3.6.0-rc.3
+      '@vue/compiler-dom': 3.6.0-rc.3
+      '@vue/compiler-ssr': 3.6.0-rc.3
+      '@vue/compiler-vapor': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.26
@@ -7548,16 +7525,16 @@ snapshots:
       '@vue/compiler-dom': 3.5.40
       '@vue/shared': 3.5.40
 
-  '@vue/compiler-ssr@3.6.0-rc.2':
+  '@vue/compiler-ssr@3.6.0-rc.3':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
 
-  '@vue/compiler-vapor@3.6.0-rc.2':
+  '@vue/compiler-vapor@3.6.0-rc.3':
     dependencies:
       '@babel/parser': 7.29.8
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -7571,11 +7548,11 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.2.1
 
-  '@vue/devtools-core@8.2.1(vue@3.5.40(typescript@6.0.3))':
+  '@vue/devtools-core@8.2.1(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       '@vue/devtools-kit': 8.2.1
       '@vue/devtools-shared': 8.2.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   '@vue/devtools-kit@7.7.10':
     dependencies:
@@ -7613,24 +7590,26 @@ snapshots:
   '@vue/reactivity@3.5.40':
     dependencies:
       '@vue/shared': 3.5.40
+    optional: true
 
   '@vue/reactivity@3.5.41':
     dependencies:
       '@vue/shared': 3.5.41
 
-  '@vue/reactivity@3.6.0-rc.2':
+  '@vue/reactivity@3.6.0-rc.3':
     dependencies:
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/shared': 3.6.0-rc.3
 
   '@vue/runtime-core@3.5.40':
     dependencies:
       '@vue/reactivity': 3.5.40
       '@vue/shared': 3.5.40
+    optional: true
 
-  '@vue/runtime-core@3.6.0-rc.2':
+  '@vue/runtime-core@3.6.0-rc.3':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/reactivity': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
 
   '@vue/runtime-dom@3.5.40':
     dependencies:
@@ -7638,59 +7617,61 @@ snapshots:
       '@vue/runtime-core': 3.5.40
       '@vue/shared': 3.5.40
       csstype: 3.2.3
+    optional: true
 
-  '@vue/runtime-dom@3.6.0-rc.2':
+  '@vue/runtime-dom@3.6.0-rc.3':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.2
-      '@vue/runtime-core': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/reactivity': 3.6.0-rc.3
+      '@vue/runtime-core': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
       csstype: 3.2.3
 
-  '@vue/runtime-vapor@3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)':
+  '@vue/runtime-vapor@3.6.0-rc.3(@vue/runtime-dom@3.6.0-rc.3)':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.2
-      '@vue/runtime-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/reactivity': 3.6.0-rc.3
+      '@vue/runtime-dom': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
 
   '@vue/server-renderer@3.5.40':
     dependencies:
       '@vue/compiler-ssr': 3.5.40
       '@vue/runtime-dom': 3.5.40
       '@vue/shared': 3.5.40
+    optional: true
 
-  '@vue/server-renderer@3.6.0-rc.2':
+  '@vue/server-renderer@3.6.0-rc.3':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-rc.2
-      '@vue/runtime-dom': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-ssr': 3.6.0-rc.3
+      '@vue/runtime-dom': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
 
   '@vue/shared@3.5.40': {}
 
   '@vue/shared@3.5.41': {}
 
-  '@vue/shared@3.6.0-rc.2': {}
+  '@vue/shared@3.6.0-rc.3': {}
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.2(typescript@6.0.3))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.3)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.3
       js-beautify: 1.15.4
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
       vue-component-type-helpers: 3.3.9
     optionalDependencies:
       '@vue/server-renderer': 3.5.40
 
-  '@vueuse/core@14.4.0(vue@3.6.0-rc.2(typescript@6.0.3))':
+  '@vueuse/core@14.4.0(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.4.0
-      '@vueuse/shared': 14.4.0(vue@3.6.0-rc.2(typescript@6.0.3))
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      '@vueuse/shared': 14.4.0(vue@3.6.0-rc.3(typescript@6.0.3))
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   '@vueuse/metadata@14.4.0': {}
 
-  '@vueuse/shared@14.4.0(vue@3.6.0-rc.2(typescript@6.0.3))':
+  '@vueuse/shared@14.4.0(vue@3.6.0-rc.3(typescript@6.0.3))':
     dependencies:
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   '@yuku-codegen/binding-android-arm64@0.8.4':
     optional: true
@@ -9270,14 +9251,14 @@ snapshots:
 
   motion-utils@12.39.0: {}
 
-  motion-v@2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.2(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.2(typescript@6.0.3)):
+  motion-v@2.3.0(@vueuse/core@14.4.0(vue@3.6.0-rc.3(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.3(typescript@6.0.3)):
     dependencies:
-      '@vueuse/core': 14.4.0(vue@3.6.0-rc.2(typescript@6.0.3))
+      '@vueuse/core': 14.4.0(vue@3.6.0-rc.3(typescript@6.0.3))
       framer-motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       hey-listen: 1.0.8
       motion-dom: 12.43.0
       motion-utils: 12.39.0
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -9457,13 +9438,13 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(cac@6.7.14)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.1.0)(rolldown@1.2.3)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.1.0)(rolldown@1.2.3)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(15754dd0f631e422567e3376fb3c4571)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(8d5dcde6d9ff1f2e7e31b48955dfaa25)
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@nuxt/vite-builder': 4.5.2(40b36f2289899658236a1b39fc4ead2b)
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
       compatx: 0.2.0
@@ -9512,9 +9493,9 @@ snapshots:
       unrouting: 0.2.2
       untyped: 2.0.0
       verkit: 0.3.2
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
       vue-component-type-helpers: 3.3.9
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
     optionalDependencies:
       '@types/node': 26.1.1
     transitivePeerDependencies:
@@ -10699,7 +10680,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin-vue@7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.3)(rollup@4.62.4)(terser@5.49.2)(vue@3.6.0-rc.2(typescript@6.0.3))(yaml@2.9.0):
+  unplugin-vue@7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.3)(rollup@4.62.4)(terser@5.49.2)(vue@3.6.0-rc.3(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -10707,7 +10688,7 @@ snapshots:
       obug: 2.1.4
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -10799,11 +10780,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vee-validate@4.15.1(vue@3.6.0-rc.2(typescript@6.0.3)):
+  vee-validate@4.15.1(vue@3.6.0-rc.3(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 7.7.10
       type-fest: 4.41.0
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   verkit@0.3.2: {}
 
@@ -10880,7 +10861,7 @@ snapshots:
     optionalDependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
 
-  vite-plugin-vue-tracer@1.4.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
+  vite-plugin-vue-tracer@1.4.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.1.1
@@ -10888,24 +10869,24 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
   vite-ssg-sitemap@0.10.0: {}
 
-  vite-ssg@28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3)))(vue@3.6.0-rc.2(typescript@6.0.3)):
+  vite-ssg@28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3)))(vue@3.6.0-rc.3(typescript@6.0.3)):
     dependencies:
       '@unhead/dom': 2.1.17(unhead@2.1.17)
-      '@unhead/vue': 2.1.17(vue@3.6.0-rc.2(typescript@6.0.3))
+      '@unhead/vue': 2.1.17(vue@3.6.0-rc.3(typescript@6.0.3))
       ansis: 4.3.1
       cac: 6.7.14
       html-minifier-terser: 7.2.0
       html5parser: 2.0.2
       jsdom: 28.1.0(supports-color@10.2.2)
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
     optionalDependencies:
       beasties: 0.4.3
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3))
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3))
     transitivePeerDependencies:
       - '@noble/hashes'
       - canvas
@@ -10927,11 +10908,11 @@ snapshots:
       terser: 5.49.2
       yaml: 2.9.0
 
-  vitest-browser-vue@2.1.0(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.2(typescript@6.0.3)):
+  vitest-browser-vue@2.1.0(@vue/compiler-dom@3.6.0-rc.3)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.3(typescript@6.0.3)):
     dependencies:
-      '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.6.0-rc.2)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.2(typescript@6.0.3))
+      '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.6.0-rc.3)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.3(typescript@6.0.3))
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0(supports-color@10.2.2))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - '@vue/server-renderer'
@@ -10995,18 +10976,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-i18n@11.4.8(vue@3.6.0-rc.2(typescript@6.0.3)):
+  vue-i18n@11.4.8(vue@3.6.0-rc.3(typescript@6.0.3)):
     dependencies:
       '@intlify/core-base': 11.4.8
       '@intlify/devtools-types': 11.4.8
       '@intlify/shared': 11.4.8
       '@vue/devtools-api': 6.6.4
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
 
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.3(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.4(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 3.1.4(vue@3.6.0-rc.3(typescript@6.0.3))
       '@vue/devtools-api': 8.2.1
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
@@ -11022,41 +11003,7 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      vue: 3.5.40(typescript@6.0.3)
-      yaml: 2.9.0
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.40
-      vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - webpack
-
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.6.0-rc.2(typescript@6.0.3)):
-    dependencies:
-      '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.4(vue@3.6.0-rc.2(typescript@6.0.3))
-      '@vue/devtools-api': 8.2.1
-      ast-walker-scope: 0.9.0
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      nostics: 1.2.0
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
-      unplugin-utils: 0.3.2
-      vue: 3.6.0-rc.2(typescript@6.0.3)
+      vue: 3.6.0-rc.3(typescript@6.0.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
@@ -11077,24 +11024,14 @@ snapshots:
       '@vue/language-core': 3.3.9
       typescript: 6.0.3
 
-  vue@3.5.40(typescript@6.0.3):
+  vue@3.6.0-rc.3(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.40
-      '@vue/compiler-sfc': 3.5.40
-      '@vue/runtime-dom': 3.5.40
-      '@vue/server-renderer': 3.5.40
-      '@vue/shared': 3.5.40
-    optionalDependencies:
-      typescript: 6.0.3
-
-  vue@3.6.0-rc.2(typescript@6.0.3):
-    dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.2
-      '@vue/compiler-sfc': 3.6.0-rc.2
-      '@vue/runtime-dom': 3.6.0-rc.2
-      '@vue/runtime-vapor': 3.6.0-rc.2(@vue/runtime-dom@3.6.0-rc.2)
-      '@vue/server-renderer': 3.6.0-rc.2
-      '@vue/shared': 3.6.0-rc.2
+      '@vue/compiler-dom': 3.6.0-rc.3
+      '@vue/compiler-sfc': 3.6.0-rc.3
+      '@vue/runtime-dom': 3.6.0-rc.3
+      '@vue/runtime-vapor': 3.6.0-rc.3(@vue/runtime-dom@3.6.0-rc.3)
+      '@vue/server-renderer': 3.6.0-rc.3
+      '@vue/shared': 3.6.0-rc.3
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,21 @@ allowBuilds:
   sharp: true
 overrides:
   brace-expansion: '>=5.0.8'
+  vue: 3.6.0-rc.3
 minimumReleaseAgeExclude:
   - '@vue/language-core@3.3.8'
   - vue-tsc@3.3.8
   - lint-staged@17.2.0
   - vue-component-type-helpers@3.3.8
+  - vue@3.6.0-rc.3
+  - '@vue/compiler-core@3.6.0-rc.3'
+  - '@vue/compiler-dom@3.6.0-rc.3'
+  - '@vue/compiler-sfc@3.6.0-rc.3'
+  - '@vue/compiler-ssr@3.6.0-rc.3'
+  - '@vue/compiler-vapor@3.6.0-rc.3'
+  - '@vue/reactivity@3.6.0-rc.3'
+  - '@vue/runtime-core@3.6.0-rc.3'
+  - '@vue/runtime-dom@3.6.0-rc.3'
+  - '@vue/runtime-vapor@3.6.0-rc.3'
+  - '@vue/server-renderer@3.6.0-rc.3'
+  - '@vue/shared@3.6.0-rc.3'


### PR DESCRIPTION
## Summary
- An external `class` passed to a component (e.g. `<Message class="my-class">`) was silently replacing the component's own internal styling classes instead of merging with them, under `vael-ui/vapor`. Confirmed and reproduced: `className` came back as literally `"my-class"` only, `ui-message`/`ui-message--warning` gone entirely.
- Fixed by applying `inheritAttrs: false` + `useAttrs()` + `v-bind="attrs"` to 36 components that were relying on Vapor's implicit fallthrough (which doesn't reliably merge `class` when the component already binds its own) — matching the pattern `Button.vue` already used correctly. Verified fixed via a real Vapor render + DOM inspection.
- Components whose root wraps content in `<Transition>` (Dialog, Popover, Message, Tooltip, and others) are **not** covered by this fix — traced this precisely to Vue 3.6 Vapor's own `<Transition>` implementation auto-forwarding and re-applying fallthrough attrs after the component's own render, regardless of that component's `inheritAttrs` setting. No in-library workaround exists (tried 4 different approaches). Added a permanent regression-sentinel test (`class-merge.test.ts`) documenting exactly what's fixed and what's still open, so this doesn't look like an oversight later.
- Bumped `vue` to `3.6.0-rc.3` across the workspace. This incidentally fixed a separate, previously-documented limitation: `AnimatePresence`/`<Transition>` now correctly defers exit removal through a `<Teleport>` nested inside a component (e.g. a force-mounted `Dialog`) — updated the `presence-spike.test.ts` sentinel tests to match. The imperative `beforeClose` fallback is no longer required for that case, though it remains supported.

## Verification
- Full monorepo `pnpm build`, `pnpm typecheck:only`, `pnpm --filter vael-ui test` (691/691), and `pnpm --filter vapor-ui test` (18/18, including the new sentinel) all pass clean from a from-scratch rebuild on a fresh branch off `main`.

## Test plan
- [x] `pnpm build` (root) — clean
- [x] `pnpm typecheck:only` — clean
- [x] `pnpm --filter vael-ui test` — 691/691 passed
- [x] `pnpm --filter vapor-ui test` — 18/18 passed (incl. new `class-merge.test.ts` sentinel)
- [x] Real Vapor render + DOM inspection confirming the fix for a representative non-Transition component