### PR TITLE
fix(build): give every barrel export its own chunk, not just components

### DIFF
--- a/.changeset/fix-composable-tree-shaking.md
+++ b/.changeset/fix-composable-tree-shaking.md
@@ -1,0 +1,29 @@
+---
+'vael-ui': patch
+---
+
+Fixes a tree-shaking bug where importing a single composable (e.g. `useColorScheme`) could
+silently pull unrelated components' CSS — Dialog, Popover, Dock, and others — into a consumer's
+production bundle, despite the composable never referencing them.
+
+Root cause: `tsdown.config.ts`'s build entries only covered components, discovered by walking
+`components/<Name>/<Name>.vue` directories. Anything else exported from the library's barrel
+(`useColorScheme` and ~20 other composables, plus `classes`/`theme`/`messages`/`ssr`/the
+directives) was only ever reachable _through_ that barrel, so tsdown/rolldown bundled it straight
+into the compiled `index.js` instead of splitting it into its own chunk. A downstream bundler can
+tree-shake an unused _export_, but not an unused chunk of code still sitting inside a file it
+otherwise needs — so importing that one composable kept the whole inlined region, and whatever
+unrelated component code rolldown had grouped alongside it during the library's own build.
+
+The directory walk also missed any component that doesn't fit the `<Name>/<Name>.vue` convention —
+`Column.vue`, which sits flat in `components/`, had the exact same problem.
+
+Fix: build entries are now derived directly from the barrel's own export specifiers (a new
+`collectBarrelEntries` helper, shared by `packages/ui/tsdown.config.ts` and
+`packages/vapor-ui/tsdown.config.ts`), so every component _and_ composable gets its own chunk
+automatically — accurate to whatever the barrel actually exports, present or future, without
+needing to be kept in sync by hand. `pnpm build` now also runs a `verify-chunk-splitting.mjs`
+check that fails loudly if any barrel export ever loses its own chunk again.
+
+No public API changes — every export, prop, and type stays the same. Only the compiled output's
+internal chunking changed, which is what fixes the leak.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Animation-agnostic Vue 3 UI library with full Vue Vapor support.",
   "type": "module",
   "scripts": {
-    "build": "pnpm --filter vael-ui build && pnpm --filter vapor-ui build",
+    "build": "pnpm --filter vael-ui build && pnpm --filter vapor-ui build && node packages/scripts/verify-chunk-splitting.mjs",
     "build:vapor": "pnpm --filter vapor-ui build",
     "typecheck": "pnpm build && pnpm typecheck:only",
     "typecheck:only": "pnpm --filter vael-ui typecheck && pnpm --filter vdom typecheck && pnpm --filter vapor-interop typecheck && pnpm --filter vapor typecheck && pnpm --filter vapor-ui typecheck && pnpm --filter docs typecheck",

--- a/packages/scripts/collect-barrel-entries.mjs
+++ b/packages/scripts/collect-barrel-entries.mjs
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+
+/**
+ * Turns every VALUE export's `from './x'` specifier in a barrel file into
+ * its own tsdown entry (as a `{ name: path }` map, since some specifiers —
+ * vapor-ui's generated barrel imports several composables straight from the
+ * sibling `ui` package's own src — resolve outside this package's root, and
+ * rolldown rejects `../`-containing paths in the plain-array entry form).
+ *
+ * A module only reachable THROUGH the barrel (never imported by another
+ * entry, e.g. a component that also uses it internally) gets bundled
+ * straight into the barrel's own compiled output instead of split into its
+ * own chunk — invisible here, but it means a downstream consumer's bundler
+ * can no longer tree-shake that one export on its own: whatever else
+ * rolldown grouped into that same inlined region comes along with it. This
+ * is what let `useColorScheme` (only ever reachable via the barrel) drag
+ * unrelated Dialog/Popover CSS into a consumer's build despite never
+ * referencing either.
+ *
+ * Deriving entries from the barrel's own specifiers, instead of walking
+ * `components/<Name>/<Name>.vue` directories, also catches anything that
+ * doesn't fit that directory convention (a flat `components/Column.vue` had
+ * the exact same gap) — it stays correct for whatever the barrel actually
+ * exports, without needing to be kept in sync by hand.
+ *
+ * `export type {...}` specifiers are skipped: types are erased at compile
+ * time, so they need no runtime chunk, and including them anyway risks a
+ * name collision whenever a file backs both a value export (already
+ * covered) and a type-only export elsewhere (e.g. vapor-ui's generated
+ * barrel re-exports `confirmAction` the value from its own local generated
+ * copy, but `ConfirmActionOptions` the type from the original ui package).
+ */
+export function collectBarrelEntries(barrelPath, cwd) {
+  const source = readFileSync(barrelPath, 'utf8')
+  const barrelDir = dirname(barrelPath)
+  const specifiers = new Set()
+  for (const match of source.matchAll(/\bexport\s+(?!type\b)[^;]*?\bfrom\s+['"](\.[^'"]+)['"]/g)) {
+    specifiers.add(match[1])
+  }
+  const entries = {}
+  for (const specifier of specifiers) {
+    const withExt = specifier.endsWith('.vue') ? specifier : `${specifier}.ts`
+    const absolute = resolve(barrelDir, withExt)
+    const path = relative(cwd, absolute)
+    // Named from the specifier itself (relative to the barrel's own
+    // directory), not from `path` (relative to `cwd`) — for a nested
+    // barrel like vapor-ui's `src/generated/index.ts`, `path` carries a
+    // `src/generated/` prefix that has nothing to do with the export's own
+    // identity and would otherwise leak into every output filename.
+    const name = withExt
+      .replace(/\.(vue|ts)$/, '')
+      .replace(/^(\.\.\/)+/, 'external/')
+      .replace(/^\.\//, '')
+      // Purely a source-layout artifact, not a meaningful part of the name.
+      .replace(/(^|\/)src\//g, '$1')
+    entries[name] = path.startsWith('.') ? path : `./${path}`
+  }
+  return entries
+}

--- a/packages/scripts/verify-chunk-splitting.mjs
+++ b/packages/scripts/verify-chunk-splitting.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Run after `pnpm build`. Confirms every value export in each barrel
+// (packages/ui/src/index.ts, packages/vapor-ui/src/generated/index.ts) has
+// its own dist chunk, matching the entries collectBarrelEntries derived at
+// build time. If a chunk is missing, tsdown/rolldown inlined that export
+// straight into the barrel's own compiled file instead of splitting it out
+// — invisible until a downstream consumer's bundler can no longer
+// tree-shake that one export on its own, and drags in whatever else got
+// bundled alongside it. This is exactly what happened to useColorScheme
+// (see the tree-sticky-scroll-vscode changeset's "Also fixes" entry, or the
+// original repro at github.com/Mini-Sylar/vue-vael-css-repro): reachable
+// only via the ui barrel, it got inlined into index.js, and importing it
+// alone dragged unrelated Dialog/Popover CSS into a consumer's build.
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { collectBarrelEntries } from './collect-barrel-entries.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function verify(label, barrelPath, distDir, cwd) {
+  const entries = collectBarrelEntries(barrelPath, cwd)
+  const missing = []
+  for (const [name, srcPath] of Object.entries(entries)) {
+    if (!existsSync(join(distDir, `${name}.js`))) missing.push({ label, name, srcPath })
+  }
+  return missing
+}
+
+const uiRoot = join(__dirname, '../ui')
+const vaporRoot = join(__dirname, '../vapor-ui')
+
+const missing = [
+  ...verify('vdom', join(uiRoot, 'src/index.ts'), join(uiRoot, 'dist'), uiRoot),
+  ...verify(
+    'vapor',
+    join(vaporRoot, 'src/generated/index.ts'),
+    join(uiRoot, 'dist/vapor'),
+    vaporRoot,
+  ),
+]
+
+if (missing.length > 0) {
+  console.error(`${missing.length} barrel export(s) missing their own dist chunk:\n`)
+  for (const m of missing) console.error(`  [${m.label}] ${m.name} (from ${m.srcPath})`)
+  console.error(
+    '\nEach of these got inlined into its barrel instead of split into its own chunk — a ' +
+      'downstream consumer can no longer tree-shake it independently. Check tsdown.config.ts\'s ' +
+      'entry list (packages/ui, packages/vapor-ui) still spreads collectBarrelEntries(...).',
+  )
+  process.exit(1)
+}
+
+console.log('OK: every barrel export (vdom + vapor) has its own dist chunk.')

--- a/packages/ui/tsdown.config.ts
+++ b/packages/ui/tsdown.config.ts
@@ -1,20 +1,15 @@
-import { existsSync, readdirSync } from 'node:fs'
 import { defineConfig } from 'tsdown'
 import Vue from 'unplugin-vue/rolldown'
-
-const componentEntries = readdirSync('./src/components', { withFileTypes: true })
-  .filter((entry) => entry.isDirectory())
-  .map((dir) => `./src/components/${dir.name}/${dir.name}.vue`)
-  .filter((path) => existsSync(path))
+import { collectBarrelEntries } from '../scripts/collect-barrel-entries.mjs'
 
 export default defineConfig({
-  entry: [
-    './src/index.ts',
-    './src/style-entry.ts',
-    './src/resolver/index.ts',
-    './src/nuxt/index.ts',
-    ...componentEntries,
-  ],
+  entry: {
+    index: './src/index.ts',
+    'style-entry': './src/style-entry.ts',
+    'resolver/index': './src/resolver/index.ts',
+    'nuxt/index': './src/nuxt/index.ts',
+    ...collectBarrelEntries('./src/index.ts', process.cwd()),
+  },
   platform: 'neutral',
   plugins: [Vue({ isProduction: true })],
   dts: { vue: true },

--- a/packages/vapor-ui/tsdown.config.ts
+++ b/packages/vapor-ui/tsdown.config.ts
@@ -1,18 +1,21 @@
-import { existsSync, readdirSync } from 'node:fs'
 import { defineConfig } from 'tsdown'
 import Vue from 'unplugin-vue/rolldown'
+import { collectBarrelEntries } from '../scripts/collect-barrel-entries.mjs'
 
-// Mirrors packages/ui/tsdown.config.ts: one entry per top-level generated
-// component dir (`<Name>/<Name>.vue`), plus the barrel. Internal-only .vue
-// files (ConfirmDialogFooter, DataTableHead, ...) are dependencies pulled in
-// via whichever entry imports them, not entries of their own.
-const componentEntries = readdirSync('./src/generated', { withFileTypes: true })
-  .filter((entry) => entry.isDirectory())
-  .map((dir) => `./src/generated/${dir.name}/${dir.name}.vue`)
-  .filter((path) => existsSync(path))
-
+// Mirrors packages/ui/tsdown.config.ts: one entry per export the generated
+// barrel actually has, derived from its own specifiers (see
+// collectBarrelEntries's own comment for why — a component/composable only
+// reachable via the barrel otherwise gets inlined into it, breaking a
+// downstream consumer's own tree-shaking). Some specifiers point outside
+// this package, straight at packages/ui/src (composables aren't copied into
+// src/generated/, only components are) — collectBarrelEntries resolves
+// those to an `external/...` entry name so rolldown's entryFileNames
+// placeholder never sees a raw `../` path.
 export default defineConfig({
-  entry: ['./src/generated/index.ts', ...componentEntries],
+  entry: {
+    index: './src/generated/index.ts',
+    ...collectBarrelEntries('./src/generated/index.ts', process.cwd()),
+  },
   outDir: '../ui/dist/vapor',
   platform: 'neutral',
   plugins: [Vue({ isProduction: true })],


### PR DESCRIPTION
## Summary
- Fixes a tree-shaking bug: importing a single composable (e.g. `useColorScheme`) could silently pull unrelated components' CSS (Dialog, Popover, Dock, ...) into a consumer's production bundle.
- Root cause: `tsdown.config.ts`'s build entries only covered components (directory walk), so anything else the barrel exported — composables, `theme`/`messages`/`classes`/`ssr`, directives — was only reachable through `index.ts` and got inlined into its compiled output instead of split into its own chunk. Also caught `Column.vue` (flat file, missed the same directory-walk convention).
- Fix: entries are now derived directly from each barrel's own export specifiers (`collectBarrelEntries`, shared by both `packages/ui` and `packages/vapor-ui` tsdown configs).
- `pnpm build` now runs `verify-chunk-splitting.mjs`, which fails loudly if this class of bug reoccurs — already wired into CI via the existing `pnpm build` step in `ci.yml`/`release.yml`.
- No public API changes.

## Test plan
- [x] Full test suite: `vael-ui` (709), `vapor-ui` (18), `vapor-interop` (8) — all passing
- [x] `pnpm typecheck:only` clean across all 6 packages/apps
- [x] Verified against two real reproductions (a minimal isolated repro and the original `vue-vael-css-repro` project) — confirmed the leak is gone in both
- [x] Live functional check in the docs site: `useColorScheme` theme toggle, Dialog (VDOM + Vapor), Tree, DataTable — all work, zero console errors
- [x] `verify-chunk-splitting.mjs` confirmed to fail loudly against the old buggy config, and pass against the fix