### PR TITLE
0.3.1: mobile touch drag-to-reorder + reorderSiblings drag-out fix

### DIFF
--- a/.changeset/release-0-3-1.md
+++ b/.changeset/release-0-3-1.md
@@ -1,0 +1,34 @@
+---
+'vael-ui': patch
+---
+
+## Mobile drag-to-reorder
+
+**Fixed: touch was unusable for `Tree` and `DataTable`'s column reorder** — any touch on a row/header
+committed a drag immediately, so tapping to select/expand/sort competed with dragging, and once a
+drag did start, it fought the browser's own scroll instead of taking over cleanly.
+
+- **New: `touchDragDelay`** (`useSortable`, `Sortable`, `DataTable`, `v-draggable`) — ms a touch
+  pointer must hold still before a drag starts; mouse/pen are unaffected and stay instant. Off (`0`)
+  by default everywhere, since most drag handles have no competing tap action. `Tree` and
+  `DataTable` default it to `150`, since a row/header there is also a tap target.
+- Touch scrolling on a reorderable `Tree`/`DataTable` no longer fights the drag gesture: scrolling
+  works normally until a hold commits, at which point the browser's native scroll hands off cleanly
+  to the drag.
+
+## Fixes
+
+- **`Tree`:** `reorderSiblings: false` incorrectly blocked dragging a nested item back out to the top
+  level when dropped past the last row — re-parenting out of a folder now works; reordering among
+  already-top-level siblings still correctly stays locked.
+- **`Sortable`:** holding a row past `beforeDrop`'s confirm-gate without moving it (a touch hold, or
+  a very deliberate hover) no longer shows a confirm dialog for a drop that didn't actually change
+  anything.
+- **`Tree`:** removed the press-scale effect on rows — read as an unintentional wobble rather than
+  feedback.
+- **`v-draggable`**: the "plain list with a handle" pattern's grip icon is now a properly sized touch
+  target (was ~8×19px).
+
+## Docs
+
+- `Sortable` now correctly shows the sidebar's "new" indicator.

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "gen": "node scripts/extract-component-meta.mjs && node scripts/generate-doc-demos.mjs",
-    "dev": "pnpm gen && vite",
+    "dev": "pnpm gen && vite --host",
     "build": "pnpm gen && vite-ssg build",
     "typecheck": "pnpm gen && vue-tsc --noEmit",
     "preview": "pnpm gen && vite preview"

--- a/docs/src/demos/Sortable/06-VDraggableReorderableTabs.vue
+++ b/docs/src/demos/Sortable/06-VDraggableReorderableTabs.vue
@@ -35,7 +35,10 @@ import { Tabs, vDraggable } from 'vael-ui'
 
 const tabs = reactive(['Overview', 'Activity', 'Settings'])
 const activeTab = shallowRef('Overview')
-const tabsDraggable = computed(() => ({ items: tabs, axis: 'x' as const }))
+// Each tab is also a click target (switches the active tab) — touchDragDelay
+// gives touch a hold to tell "select this tab" from "drag it" apart. A plain
+// dedicated handle (see the demo below) doesn't need this.
+const tabsDraggable = computed(() => ({ items: tabs, axis: 'x' as const, touchDragDelay: 150 }))
 </script>
 
 <style scoped>

--- a/docs/src/demos/Sortable/07-VDraggablePlainListWithHandle.vue
+++ b/docs/src/demos/Sortable/07-VDraggablePlainListWithHandle.vue
@@ -47,7 +47,17 @@ const filesDraggable = computed(() => ({ items: files, handle: '[data-grip]' }))
   opacity: 0;
 }
 .draggable-file-grip {
+  /* The glyph itself is a few px wide — this is the actual touch target,
+     roughly WCAG's 44px minimum, without visually enlarging the row. */
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  inline-size: 2.75rem;
+  block-size: 2.75rem;
+  margin: -0.5rem -0.625rem -0.5rem -0.375rem;
   color: var(--ui-text-muted);
+  font-size: 1rem;
   cursor: grab;
   touch-action: none;
 }

--- a/docs/src/taxonomy.ts
+++ b/docs/src/taxonomy.ts
@@ -131,6 +131,7 @@ export const NEW_COMPONENTS: Record<string, string> = {
   PasswordInput: '2026-08-16',
   Rating: '2026-08-23',
   Timeline: '2026-08-23',
+  Sortable: '2026-08-30',
 }
 
 export const NEW_BADGE_DAYS = 14

--- a/packages/ui/src/components/DataTable/DataTable.vue
+++ b/packages/ui/src/components/DataTable/DataTable.vue
@@ -180,6 +180,11 @@ const props = withDefaults(
      * lost from the DOM entirely on drop. Kept only for interface symmetry with
      * `Sortable`/`Tree`, where it's safe. */
     previewMode?: 'element' | 'clone'
+    /** Ms a touch pointer must hold a column header still before a drag
+     * starts. A sortable column's header is also a tap-to-sort button, so
+     * touch needs a hold to tell the two apart; mouse/pen are unaffected.
+     * Default `150`. */
+    touchDragDelay?: number
   }>(),
   {
     loading: false,
@@ -199,6 +204,7 @@ const props = withDefaults(
     canDrop: undefined,
     beforeDrop: undefined,
     previewMode: 'clone',
+    touchDragDelay: 150,
   },
 )
 
@@ -703,6 +709,7 @@ const {
   axis: 'x',
   dragPreview: true,
   previewMode: () => props.previewMode,
+  touchDragDelay: () => props.touchDragDelay,
   disabled: () => !props.reorderableColumns,
   motionCss: () => props.motionCss,
   canDrop: (details) => {

--- a/packages/ui/src/components/Sortable/Sortable.vue
+++ b/packages/ui/src/components/Sortable/Sortable.vue
@@ -115,6 +115,10 @@ const props = withDefaults(
      * a separate floating copy, for content that can't tolerate leaving its
      * normal layout. */
     previewMode?: 'element' | 'clone'
+    /** Ms a touch pointer must hold a row still before a drag starts. Skip
+     * this unless `#item`/`#handle` content is also tappable for something
+     * else — the built-in handle alone never needs it. Default `0`. */
+    touchDragDelay?: number
     ui?: Partial<{
       root: UiPartValue
       item: UiPartValue
@@ -192,6 +196,7 @@ const {
   group: props.group,
   groupId: () => props.groupId,
   previewMode: () => props.previewMode ?? 'element',
+  touchDragDelay: () => props.touchDragDelay ?? 0,
   canDrop: (details) => props.canDrop?.(details) ?? true,
   beforeDrop: props.beforeDrop ? (details) => props.beforeDrop!(details) : undefined,
   onDropError: (error, details) => emit('drop-error', error, details),

--- a/packages/ui/src/components/Tree/Tree.css
+++ b/packages/ui/src/components/Tree/Tree.css
@@ -88,6 +88,13 @@
     cursor: pointer;
     user-select: none;
   }
+  /* Static, not set from JS — the browser reads touch-action at the moment
+     of contact, before any handler runs, so setting it reactively is
+     always too late. useSortable's touchDragDelay drives scrolling by hand
+     instead once a hold loses to an early move. */
+  .ui-tree[data-reorderable] .ui-tree-row {
+    touch-action: none;
+  }
   .ui-tree-row:hover:not(.ui-tree-row--disabled),
   .ui-tree-row:focus-visible {
     background: var(--ui-muted);

--- a/packages/ui/src/components/Tree/Tree.vue
+++ b/packages/ui/src/components/Tree/Tree.vue
@@ -34,6 +34,7 @@
       ref="listEl"
       :id="listId"
       role="tree"
+      :data-reorderable="reorderable ? '' : undefined"
       :data-reordering="isReordering ? '' : undefined"
       :data-invalid-drop="isReordering && !isValidDrop ? '' : undefined"
       :data-drop-pending="isDropPending ? '' : undefined"
@@ -292,6 +293,10 @@ const props = withDefaults(
      * only one instance of it on screen; safe here since a tree row is a
      * plain element, not a `<table>` row. */
     previewMode?: 'element' | 'clone'
+    /** Ms a touch pointer must hold a row still before a drag starts — a row
+     * is also tap-to-select/expand here, so touch needs a hold to tell the
+     * two apart; mouse/pen are unaffected. Default `150`. */
+    touchDragDelay?: number
     /** When true, clicking anywhere on a folder row also toggles its expansion, not just the chevron —
      * it still selects too (unless `selectableFolders` is off), so picking the folder itself (without
      * opening it to reach a file inside) still works. Off by default since it changes what a plain row
@@ -325,6 +330,7 @@ const props = withDefaults(
     canDrop: undefined,
     beforeDrop: undefined,
     previewMode: 'clone',
+    touchDragDelay: 150,
     autoExpandDelay: 600,
     expandOnRowClick: false,
     stickyScroll: false,
@@ -628,6 +634,7 @@ const {
   dropOnTarget: true,
   dragPreview: true,
   previewMode: () => props.previewMode,
+  touchDragDelay: () => props.touchDragDelay,
   disabled: () => !props.reorderable,
   reorderSiblings: () => props.reorderSiblings,
   motionCss: () => props.motionCss,

--- a/packages/ui/src/composables/useSortable.ts
+++ b/packages/ui/src/composables/useSortable.ts
@@ -341,6 +341,9 @@ export interface UseSortableOptions {
   /** `nested` only. Px of indent per depth level — match whatever your rows
    * actually render with. Default `16`. */
   indentWidth?: MaybeRefOrGetter<number>
+  /** Ms a touch pointer must hold still before a drag can start. Mouse/pen
+   * are unaffected — still an immediate distance-threshold commit. Default `150`. */
+  touchDragDelay?: MaybeRefOrGetter<number>
   /** Turns off dragging; the handlers below become no-ops. */
   disabled?: MaybeRefOrGetter<boolean>
   /** `false` disables the built-in springs — positions snap. */
@@ -565,6 +568,9 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
   }
   function indentWidth(): number {
     return toValue(options.indentWidth) ?? 16
+  }
+  function touchDelay(): number {
+    return toValue(options.touchDragDelay) ?? 0
   }
   function isDisabled(): boolean {
     return toValue(options.disabled) ?? false
@@ -916,6 +922,18 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
       return
     }
 
+    // touchDragDelay can commit a grab before any movement — dropped back
+    // at the exact same spot, that's a no-op, not a real drop.
+    if (
+      sourceFrom &&
+      at.parentValue === sourceFrom.parentValue &&
+      at.index === sourceFrom.index &&
+      at.depth === sourceFrom.depth
+    ) {
+      finish()
+      return
+    }
+
     // Blocked target: never commit, just spring everything home.
     if (!isValidDrop.value) {
       say('cancel')
@@ -1004,6 +1022,7 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
     destroyPreview()
     if (!el) return
     el.style.zIndex = ''
+    el.style.touchAction = ''
     el.removeAttribute('data-dragging')
   }
 
@@ -1060,6 +1079,36 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
   let previewEl: HTMLElement | null = null
   let previewSourceEl: HTMLElement | null = null
   let lastPointerEvent: PointerEvent | null = null
+  // Drives the raw touchmove listener below — preventDefault() on a
+  // PointerEvent doesn't reliably cancel the touch scroll it came from.
+  let isTouchPointer = false
+  // Touch only — `true` for every other pointer type. See touchDragDelay.
+  let touchArmed = true
+  let touchHoldTimer: ReturnType<typeof setTimeout> | null = null
+  function clearTouchHoldTimer() {
+    if (touchHoldTimer != null) clearTimeout(touchHoldTimer)
+    touchHoldTimer = null
+  }
+  // Nearest scrollable ancestor along the sort axis — driven by hand while
+  // the hold is pending (see manualScrolling in onPointerMove), since
+  // touch-action: none takes native scrolling off the table entirely.
+  let touchScrollEl: HTMLElement | null = null
+  let manualScrolling = false
+  let lastScrollPos = 0
+  function findScrollableAncestor(el: HTMLElement | null): HTMLElement | null {
+    const prop = axis() === 'x' ? 'overflowX' : 'overflowY'
+    const overflows = (node: Element) =>
+      axis() === 'x' ? node.scrollWidth > node.clientWidth : node.scrollHeight > node.clientHeight
+    let node = el?.parentElement ?? null
+    while (node && node !== document.body && node !== document.documentElement) {
+      const style = getComputedStyle(node)
+      if (/(auto|scroll)/.test(style[prop]) && overflows(node)) return node
+      node = node.parentElement
+    }
+    // Most lists aren't boxed in their own container — the page scrolls.
+    const page = document.scrollingElement
+    return page instanceof HTMLElement && overflows(page) ? page : null
+  }
   let grabOffsetX = 0
   let grabOffsetY = 0
 
@@ -1202,50 +1251,119 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
     startY = event.clientY
     lastAlong = event.clientY
     lastTime = performance.now()
+    lastPointerEvent = event
     velocity = 0
+    isTouchPointer = event.pointerType === 'touch'
     // Resolved through the consumer's own accessor, not a DOM selector — Tree
     // rows and Sortable rows share no markup, and a selector only one of them
     // has silently disables capture and the drag preview for the other.
     dragEl = options.getElement(value)
+
+    clearTouchHoldTimer()
+    manualScrolling = false
+    touchScrollEl = null
+    const delay = touchDelay()
+    if (event.pointerType === 'touch' && delay > 0) {
+      touchArmed = false
+      touchScrollEl = findScrollableAncestor(dragEl)
+      // Now, synchronously — see this variable's own comment above.
+      if (dragEl) dragEl.style.touchAction = 'none'
+      const heldPointerId = pointerId
+      touchHoldTimer = setTimeout(() => {
+        touchHoldTimer = null
+        // Only arm the gesture this was actually scheduled for.
+        if (pointerId !== heldPointerId || committed) return
+        touchArmed = true
+        if (lastPointerEvent) commitDrag(lastPointerEvent)
+      }, delay)
+    } else {
+      // 0 is "off" outright, not a same-tick timer that risks losing a
+      // race with an immediately following pointermove.
+      touchArmed = true
+    }
+  }
+
+  /** Springs up the preview, captures the pointer, tells a `group` a
+   * session started. Called on the first move past the ordinary distance
+   * threshold, or once a touch pointer's hold completes. */
+  function commitDrag(event: PointerEvent): boolean {
+    if (pendingValue == null) return false
+    if (!begin(pendingValue, 'pointer')) {
+      pointerId = null
+      return false
+    }
+    committed = true
+    isDragging.value = true
+    try {
+      dragEl?.setPointerCapture(pointerId!)
+    } catch {
+      // Capture is an optimisation (it keeps tracking when the pointer
+      // leaves the element); losing it must not abandon the drag itself.
+    }
+    if (dragEl) {
+      dragEl.setAttribute('data-dragging', '')
+      dragEl.style.touchAction = 'none'
+      // dragPreview (DataTable/Tree's own reorder) always wants its preview
+      // right away, defaulting to 'clone' (unlike the group codepath below,
+      // which defaults to 'element') since this is the codepath a real
+      // <table> row goes through. A grouped reorder that never actually
+      // leaves this list looks and behaves exactly like a plain drag — the
+      // real element translates, nothing lifted — createPreview only fires
+      // later, lazily, if the drag actually crosses into a foreign host
+      // (see onHostChange below).
+      if (toValue(options.dragPreview))
+        createPreview(dragEl, event, toValue(options.previewMode) ?? 'clone')
+      else dragEl.style.zIndex = '1'
+    }
+    if (options.group && ownGroupId != null) {
+      options.group.__beginSession(ownGroupId, pendingValue, 'pointer')
+    }
+    return true
   }
 
   function onPointerMove(event: PointerEvent) {
     if (pointerId === null || event.pointerId !== pointerId || pendingValue == null) return
     lastPointerEvent = event
+
+    if (manualScrolling) {
+      // touch-action was already 'none' — we are the scroll now.
+      if (touchScrollEl) {
+        const pos = axis() === 'x' ? event.clientX : event.clientY
+        if (axis() === 'x') touchScrollEl.scrollLeft -= pos - lastScrollPos
+        else touchScrollEl.scrollTop -= pos - lastScrollPos
+        lastScrollPos = pos
+      }
+      return
+    }
+
+    // A pending touch hold owns this gesture from its very first move —
+    // never the browser's compositor, which can otherwise commit to a
+    // native scroll before our own threshold check runs.
+    if (!committed && !touchArmed) event.preventDefault()
+
     const dx = event.clientX - startX
     const dy = event.clientY - startY
 
     if (!committed) {
       if (Math.abs(dy) < DRAG_THRESHOLD && Math.abs(dx) < DRAG_THRESHOLD) return
-      if (!begin(pendingValue, 'pointer')) {
-        pointerId = null
+      if (!touchArmed) {
+        // Moved before the hold completed — this is a scroll, not a drag.
+        clearTouchHoldTimer()
+        if (dragEl) dragEl.style.touchAction = ''
+        if (touchScrollEl) {
+          manualScrolling = true
+          // Apply the move that crossed the threshold too, or those first
+          // few px go missing.
+          if (axis() === 'x') touchScrollEl.scrollLeft -= dx
+          else touchScrollEl.scrollTop -= dy
+          lastScrollPos = axis() === 'x' ? event.clientX : event.clientY
+        } else {
+          pointerId = null
+          pendingValue = null
+        }
         return
       }
-      committed = true
-      isDragging.value = true
-      try {
-        dragEl?.setPointerCapture(pointerId)
-      } catch {
-        // Capture is an optimisation (it keeps tracking when the pointer
-        // leaves the element); losing it must not abandon the drag itself.
-      }
-      if (dragEl) {
-        dragEl.setAttribute('data-dragging', '')
-        // dragPreview (DataTable/Tree's own reorder) always wants its preview
-        // right away, defaulting to 'clone' (unlike the group codepath below,
-        // which defaults to 'element') since this is the codepath a real
-        // <table> row goes through. A grouped reorder that never actually
-        // leaves this list looks and behaves exactly like a plain drag — the
-        // real element translates, nothing lifted — createPreview only fires
-        // later, lazily, if the drag actually crosses into a foreign host
-        // (see onHostChange below).
-        if (toValue(options.dragPreview))
-          createPreview(dragEl, event, toValue(options.previewMode) ?? 'clone')
-        else dragEl.style.zIndex = '1'
-      }
-      if (options.group && ownGroupId != null) {
-        options.group.__beginSession(ownGroupId, pendingValue, 'pointer')
-      }
+      if (!commitDrag(event)) return
     }
 
     event.preventDefault()
@@ -1281,7 +1399,10 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
       const hovered = resolveHoveredIndex(bands, pointer)
       const row = hovered === -1 ? null : remaining[hovered]!
       const nestable = !!row && (options.canNestInto?.(row.value) ?? true)
-      if (!nestable && !siblingReorderAllowed()) {
+      // Empty space past every row always resolves to top level (see
+      // resolveTargetDrop's `!row` case) — reaching it is a re-parent, not a
+      // sibling reorder, unless the dragged item was already top-level.
+      if (!nestable && !siblingReorderAllowed() && (row || sourceFrom?.parentValue === null)) {
         scheduleAutoExpand(null)
         dropIntoValue.value = null
         dropTargetValue.value = null
@@ -1325,11 +1446,15 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
 
   function endPointer(event: PointerEvent) {
     if (pointerId === null || event.pointerId !== pointerId) return
+    clearTouchHoldTimer()
+    manualScrolling = false
+    touchScrollEl = null
     const wasCommitted = committed
     pointerId = null
     pendingValue = null
     committed = false
     if (!wasCommitted) {
+      if (dragEl) dragEl.style.touchAction = ''
       dragEl = null
       return
     }
@@ -1349,6 +1474,7 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
   function onWindowKeydown(event: KeyboardEvent) {
     if (event.key !== 'Escape' || !isDragging.value) return
     event.preventDefault()
+    clearTouchHoldTimer()
     pointerId = null
     committed = false
     pendingValue = null
@@ -1366,6 +1492,17 @@ export function useSortable(options: UseSortableOptions): UseSortableReturn {
   useEventListener(ssrWindow, 'pointermove', onPointerMove)
   useEventListener(ssrWindow, 'pointerup', endPointer)
   useEventListener(ssrWindow, 'pointercancel', endPointer)
+  // preventDefault() on a PointerEvent doesn't reliably cancel a touch
+  // scroll — only the real TouchEvent does, and only non-passive (window's
+  // own touchmove default). Backs up touch-action: none on the row itself.
+  useEventListener(
+    ssrWindow,
+    'touchmove',
+    (event: TouchEvent) => {
+      if (pointerId !== null && isTouchPointer) event.preventDefault()
+    },
+    { passive: false },
+  )
 
   // --- keyboard --------------------------------------------------------------
 

--- a/packages/ui/src/directives/vDraggable.ts
+++ b/packages/ui/src/directives/vDraggable.ts
@@ -12,6 +12,11 @@ export interface DraggableOptions<T = unknown> {
   disabled?: boolean
   /** CSS selector for the grab surface inside each child. Defaults to the whole child. */
   handle?: string
+  /** Ms a touch pointer must hold a child still before a drag starts. Skip
+   * this unless a child is also tappable for something else (selects,
+   * activates) — a dedicated `handle` with no other purpose never needs it,
+   * mouse/pen are unaffected either way. Default `0`. */
+  touchDragDelay?: number
   /** Fires on a committed drop, with the old and new index — there's no stable
    * key here to identify the moved item by, only its position. */
   onReorder?: (from: number, to: number) => void
@@ -83,6 +88,7 @@ function start(el: HTMLElement, value: DraggableValue): void {
       axis: () => options.axis ?? 'y',
       disabled: () => options.disabled ?? false,
       dragPreview: true,
+      touchDragDelay: () => options.touchDragDelay ?? 0,
       group: options.group,
       groupId: () => options.groupId,
       onCommit: (from, to) => {

--- a/packages/ui/tests/tree-reorder.test.ts
+++ b/packages/ui/tests/tree-reorder.test.ts
@@ -202,6 +202,107 @@ test('previewMode "element" moves the real row itself instead of a floating clon
   await vi.waitFor(() => expect(getComputedStyle(row).position).not.toBe('fixed'))
 })
 
+test('touch: an early move scrolls the page when the row has no closer scroll container', async () => {
+  // Most real pages don't box a Tree in its own overflow:auto container —
+  // the page itself scrolls. Without a fallback to document.scrollingElement,
+  // touch-action: none (set the instant the hold begins, so a real drag
+  // isn't lost to the browser's own scroll decision) leaves an early move
+  // with nothing to scroll at all, on either axis.
+  const spacer = document.createElement('div')
+  spacer.style.blockSize = '3000px'
+  document.body.appendChild(spacer)
+  window.scrollTo(0, 0)
+
+  try {
+    const screen = render(TreeReorderFixture)
+    const row = rowFor(screen, 'a')
+    const box = row.getBoundingClientRect()
+
+    row.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        pointerId: 7,
+        button: 0,
+        pointerType: 'touch',
+        clientX: box.left + 10,
+        clientY: box.top + box.height / 2,
+      }),
+    )
+    window.dispatchEvent(
+      new PointerEvent('pointermove', {
+        bubbles: true,
+        pointerId: 7,
+        pointerType: 'touch',
+        clientX: box.left + 10,
+        clientY: box.top + box.height / 2 - 60,
+      }),
+    )
+    expect(window.scrollY).toBeGreaterThan(0)
+    window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 7 }))
+  } finally {
+    spacer.remove()
+    window.scrollTo(0, 0)
+  }
+})
+
+test('touch: moving past the threshold before the hold completes cancels the pending grab', async () => {
+  // A tap-to-select/expand row and a drag handle are the same element on
+  // Tree — without a hold delay, touch's natural drift past DRAG_THRESHOLD
+  // reads as a completed drag on every tap. This proves the opposite: an
+  // early move (a scroll, or just an imprecise tap) is let through instead.
+  const screen = render(TreeReorderFixture)
+  const row = rowFor(screen, 'a')
+  const box = row.getBoundingClientRect()
+
+  row.dispatchEvent(
+    new PointerEvent('pointerdown', {
+      bubbles: true,
+      pointerId: 5,
+      button: 0,
+      pointerType: 'touch',
+      clientX: box.left + 10,
+      clientY: box.top + box.height / 2,
+    }),
+  )
+  window.dispatchEvent(
+    new PointerEvent('pointermove', {
+      bubbles: true,
+      pointerId: 5,
+      pointerType: 'touch',
+      clientX: box.left + 10,
+      clientY: box.top + box.height / 2 + 40,
+    }),
+  )
+
+  expect(document.querySelector('[data-sortable-preview]')).toBeNull()
+  expect(row.hasAttribute('data-dragging')).toBe(false)
+  expect(getComputedStyle(row).opacity).not.toBe('0')
+
+  window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 5 }))
+})
+
+test('touch: holding still past the delay grabs the row even before it moves', async () => {
+  const screen = render(TreeReorderFixture)
+  const row = rowFor(screen, 'a')
+  const box = row.getBoundingClientRect()
+
+  row.dispatchEvent(
+    new PointerEvent('pointerdown', {
+      bubbles: true,
+      pointerId: 6,
+      button: 0,
+      pointerType: 'touch',
+      clientX: box.left + 10,
+      clientY: box.top + box.height / 2,
+    }),
+  )
+  // Default touchDragDelay is 150ms — held still, no pointermove at all.
+  await vi.waitFor(() => expect(row.hasAttribute('data-dragging')).toBe(true), { timeout: 1000 })
+
+  window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 6 }))
+  await vi.waitFor(() => expect(row.hasAttribute('data-dragging')).toBe(false))
+})
+
 test('Escape aborts a pointer drag, not just a keyboard one', async () => {
   const screen = render(TreeReorderFixture)
   const row = rowFor(screen, 'a')


### PR DESCRIPTION
## Mobile drag-to-reorder

Fixes touch being unusable for `Tree` and `DataTable`'s column reorder — any touch on a row/header committed a drag immediately, so tapping to select/expand/sort competed with dragging, and once a drag did start it fought the browser's own scroll.

- New `touchDragDelay` (`useSortable`, `Sortable`, `DataTable`, `v-draggable`) — ms a touch pointer must hold still before a drag starts. Off (`0`) by default; `Tree`/`DataTable` default it to `150` since a row/header there is also a tap target.
- Touch scrolling on a reorderable `Tree`/`DataTable` no longer fights the drag gesture — `touch-action` is now a static CSS rule (browsers decide scroll ownership at the moment of contact, before any JS runs, so setting it reactively was always too late), with manual scroll passthrough while a hold is pending.
- Confirmed working on a real Android Chrome device.

## Fixes

- **`Tree`:** `reorderSiblings: false` incorrectly blocked dragging a nested item back out to the top level when dropped past the last row. Fixed precisely: it's a re-parent (allowed) only when the dragged item wasn't already top-level — reordering among already-top-level siblings still correctly stays locked.
- **`Sortable`:** a touch hold that commits a grab with zero movement no longer shows `beforeDrop`'s confirm dialog for a drop that changed nothing.
- **`Tree`:** removed the press-scale effect on rows.
- **`v-draggable`:** enlarged the plain-list-with-handle demo's grip touch target (was ~8×19px).
- **docs:** `Sortable` now shows the sidebar's "new" badge; dev server exposed on LAN (`--host") for real-device testing.

936/936 tests passing. Patch changeset included (`.changeset/release-0-3-1.md`).