### PR TITLE
fix(ui): 0.3.2 patch

### DIFF
--- a/.changeset/release-0-3-2.md
+++ b/.changeset/release-0-3-2.md
@@ -1,0 +1,64 @@
+---
+'vael-ui': patch
+---
+
+## Fixes
+
+- **`PullToRefresh`:** dropping it into an existing scrollable layout no longer forces that
+  layout to restructure around it — `overflow-y: auto` only applies to the root when it's the
+  one actually owning the scroll (i.e. no `scrollEl` was passed). Touch handling is also more
+  reliable now: `touch-action` is set from scroll position ahead of time instead of reactively
+  mid-gesture, so the browser can't claim a pull-down drag before our own handler gets a chance
+  to.
+- **`Dialog`:** a custom `ui.panel.style` width no longer silently and permanently disables
+  `maximizable` — maximizing now always wins over a consumer's own size, regardless of whether
+  that size used logical or physical CSS properties.
+- **`Textarea`:** providing only the `#bottom-end` slot (no `#bottom-start`) no longer renders
+  it at the start position instead of the end.
+- **`Tour`:** the spotlight no longer collapses to a dim rectangle in the top-left corner for
+  the length of a step change before snapping onto the next target. The cutout's step-to-step
+  glide is now driven frame-by-frame in JS instead of a CSS `clip-path` transition, which on a
+  viewport-filling fixed layer triggered a Chromium compositor bug that mis-rasterised the whole
+  overlay while the transition was running. The glide is also quicker now and its duration
+  scales with travel distance, so a jump to a far target no longer drags.
+- **`Menu`:** a custom `#item` slot now keeps applying inside nested submenus instead of
+  silently reverting to the default row past the first level.
+- **`MenuList`:** the `#item` slot now tells you whether a row is a group label via a new
+  `isGroup` prop, instead of leaving you to reverse-engineer it from `item.items`.
+- **`Tag`, `Pagination`:** the `icon` (`Tag`) and `button`/`ellipsis`/`sizeSelect` (`Pagination`)
+  `ui` parts were declared in the props type but never actually wired to anything — passing them
+  did nothing. Both now work.
+- **Every component with a plain `class`/`:class` passthrough** (around 40 in total — `Card`,
+  `Badge`, `Chip`, `Switch`, `Sortable`, `DataTable`, and more): a consumer's own class now
+  correctly wins over the component's internal default class, matching how the `ui` prop already
+  worked. Previously the internal default always came last in the merged class string, which
+  silently defeated a consumer's own conflicting utility class whenever a class merger like
+  `tailwind-merge` was configured.
+- **Design tokens** (`--ui-primary`, `--ui-surface`, etc.) are now genuinely inside
+  `@layer ui-components`, matching what the styling guide has always said — an app's own
+  unlayered CSS reliably overrides a token now, regardless of import/bundle order. Previously the
+  tokens were shipped unlayered too, so overriding one was really an unlayered-vs-unlayered fight
+  decided by load order, not the documented "unlayered always wins" behavior.
+- **Type-checking against Vue 3.6:** several composables (`useTabIndicator`, `useVirtualizer`,
+  `useCollapse`, `usePopover`, `useTooltip`, and others) typed their DOM-element options as a
+  plain `Ref<T>`, which no longer structurally accepts what `useTemplateRef()` actually returns
+  under Vue 3.6's stricter reactivity types — even though it always worked fine at runtime. These
+  now accept both.
+- **The `ui` prop's `class`/`style` overrides** now accept anything a plain Vue `:class`/`:style`
+  binding would — arrays, objects, and combinations of those — instead of only a plain string.
+
+## New `ui` parts
+
+Previously reachable only via `:deep()` and an undocumented internal class name:
+
+- **`Button`:** `leading`, `trailing` (the icon wrappers — zero the default gap to the label
+  here instead of margin-hacking the slot content), `content`, `label` (the default-slot
+  wrapper and the label itself).
+- **`Tag`:** `label`.
+- **`Dialog`:** `maximize`, `close` (the built-in header buttons).
+- **`Message`:** `actions` (the trailing action row's wrapper).
+- **`Collapsible`:** `body` (the content wrapper inside the panel).
+
+## Also
+
+- Vue bumped to `3.6.0-rc.7`.

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "vael-ui": "workspace:*",
     "vee-validate": "^4.15.1",
     "vite-ssg": "^28.3.0",
-    "vue": "3.6.0-rc.6",
+    "vue": "3.6.0-rc.7",
     "vue-i18n": "^11.4.8",
     "vue-router": "^5.3.0"
   },

--- a/docs/src/composablesContent.ts
+++ b/docs/src/composablesContent.ts
@@ -375,7 +375,7 @@ open.value = true`,
 
   useColorScheme: {
     description:
-      'Drives `document.documentElement.dataset.theme` from a `system` / `light` / `dark` mode. `system` removes the attribute entirely and follows `prefers-color-scheme` live. This is the exact composable the docs site’s own header theme toggle uses; `persist` is structural (like ConfigProvider’s `i18n`) so you can wire in cookies, a store, or localStorage yourself instead of the composable assuming one.',
+      "Drives `document.documentElement.dataset.theme` from a `system` / `light` / `dark` mode. `system` removes the attribute entirely and follows `prefers-color-scheme` live. This is the exact composable the docs site’s own header theme toggle uses; `persist` is structural (like ConfigProvider’s `i18n`) so you can wire in cookies, a store, or localStorage yourself instead of the composable assuming one. Being a plain composable, it can only apply the saved mode once your JS bundle runs a component's `setup()` — after first paint. A returning user with a saved `dark` preference will see a flash of the light theme first unless you also set the attribute synchronously before Vue mounts; see the pre-hydration snippet below.",
     exampleCode: `import { useColorScheme } from 'vael-ui'
 
 const { mode, resolvedMode, setMode } = useColorScheme({
@@ -391,7 +391,24 @@ const { mode, resolvedMode, setMode } = useColorScheme({
 
 // mode.value: 'system' | 'light' | 'dark' (what the user picked)
 // resolvedMode.value: 'light' | 'dark' (what's actually applied right now)
-setMode('dark')`,
+setMode('dark')
+
+// Avoiding a flash of the wrong theme on load
+// ---------------------------------------------
+// useColorScheme can't run before Vue mounts, so a returning user with a
+// saved preference sees the default theme for a frame first. Set the
+// attribute synchronously in a blocking <script> in your HTML's <head>,
+// before your app's bundle loads — same trick as next-themes/Nuxt color-mode.
+// Match whatever persist.get()/set() convention you wired up above.
+//
+//   <script>
+//     (function () {
+//       var saved = localStorage.getItem('theme') // your own persist.get()
+//       if (saved === 'light' || saved === 'dark') {
+//         document.documentElement.dataset.theme = saved
+//       }
+//     })()
+//   </script>`,
     params: [
       {
         name: 'initial',

--- a/docs/src/composablesContent.ts
+++ b/docs/src/composablesContent.ts
@@ -59,7 +59,11 @@ export const composablesContent: Record<string, ComposableContent> = {
         description:
           'Extra content between the description and the buttons, e.g. a "type DELETE" input.',
       },
-      { name: 'surface', type: "'dialog' | 'popover'", description: "Default 'dialog'." },
+      {
+        name: 'surface',
+        type: "'dialog' | 'popover'",
+        description: "Default 'dialog'.",
+      },
       {
         name: 'position / size',
         type: 'DialogPosition / DialogSize',
@@ -257,14 +261,26 @@ open.value = true`,
         description: 'Echoed straight back from options.id.',
       },
       { name: 'currentIndex', type: 'Ref<number>', description: '' },
-      { name: 'currentStep', type: 'ComputedRef<TourStep | undefined>', description: '' },
-      { name: 'currentGroup', type: 'ComputedRef<string | undefined>', description: '' },
+      {
+        name: 'currentStep',
+        type: 'ComputedRef<TourStep | undefined>',
+        description: '',
+      },
+      {
+        name: 'currentGroup',
+        type: 'ComputedRef<string | undefined>',
+        description: '',
+      },
       {
         name: 'groups',
         type: 'ComputedRef<TourGroup[]>',
         description: '{ group, steps }[], bucketed in first-seen order.',
       },
-      { name: 'total / isFirst / isLast', type: 'ComputedRef', description: '' },
+      {
+        name: 'total / isFirst / isLast',
+        type: 'ComputedRef',
+        description: '',
+      },
       {
         name: 'isTransitioning',
         type: 'Ref<boolean>',
@@ -282,7 +298,11 @@ open.value = true`,
         type: '() => void',
         description: 'Fires onSkip and sets open.value = false.',
       },
-      { name: 'goTo', type: '(index: number) => Promise<void>', description: '' },
+      {
+        name: 'goTo',
+        type: '(index: number) => Promise<void>',
+        description: '',
+      },
       {
         name: 'goToGroup',
         type: '(group: string) => Promise<void>',
@@ -401,14 +421,14 @@ setMode('dark')
 // before your app's bundle loads — same trick as next-themes/Nuxt color-mode.
 // Match whatever persist.get()/set() convention you wired up above.
 //
-//   <script>
-//     (function () {
-//       var saved = localStorage.getItem('theme') // your own persist.get()
-//       if (saved === 'light' || saved === 'dark') {
-//         document.documentElement.dataset.theme = saved
-//       }
-//     })()
-//   </script>`,
+    <script>
+       (function () {
+         var saved = localStorage.getItem('theme') // your own persist.get()
+         if (saved === 'light' || saved === 'dark') {
+           document.documentElement.dataset.theme = saved
+         }
+       })()
+     </script>`,
     params: [
       {
         name: 'initial',
@@ -446,7 +466,11 @@ setMode('dark')
       'The Floating UI-backed positioning engine behind `Popover`, `Menu`, and `Tooltip`. Computes `positionerStyle` (absolute inset + `visibility`) against a reference/floating element pair, with flip/shift collision handling and live `autoUpdate` tracking while `active` is true. Reach for this directly when building a custom anchored surface none of the existing overlay components fit.',
     hasLiveDemo: true,
     params: [
-      { name: 'referenceEl', type: 'Ref<HTMLElement | null>', description: 'The anchor.' },
+      {
+        name: 'referenceEl',
+        type: 'Ref<HTMLElement | null>',
+        description: 'The anchor.',
+      },
       {
         name: 'floatingEl',
         type: 'Ref<HTMLElement | null>',
@@ -457,7 +481,11 @@ setMode('dark')
         type: 'MaybeRefOrGetter<boolean>',
         description: 'Positioning (and autoUpdate scroll/resize tracking) only runs while true.',
       },
-      { name: 'side', type: 'MaybeRefOrGetter<Side>', description: "Default 'bottom'." },
+      {
+        name: 'side',
+        type: 'MaybeRefOrGetter<Side>',
+        description: "Default 'bottom'.",
+      },
       {
         name: 'align',
         type: "MaybeRefOrGetter<'start' | 'center' | 'end'>",
@@ -514,8 +542,16 @@ setMode('dark')
       'Windowed rendering for long lists: only the visible rows (plus overscan) exist in the DOM. This is what `Select`/`Combobox`/`Tree` reach for once their list gets large; use it directly when building a custom scrollable list that needs the same treatment.',
     hasLiveDemo: true,
     params: [
-      { name: 'containerEl', type: 'Ref<HTMLElement | null>', description: 'The scrollable box.' },
-      { name: 'count', type: 'MaybeRefOrGetter<number>', description: 'Total row count.' },
+      {
+        name: 'containerEl',
+        type: 'Ref<HTMLElement | null>',
+        description: 'The scrollable box.',
+      },
+      {
+        name: 'count',
+        type: 'MaybeRefOrGetter<number>',
+        description: 'Total row count.',
+      },
       {
         name: 'itemSize',
         type: 'MaybeRefOrGetter<number | undefined>',
@@ -635,7 +671,11 @@ setMode('dark')
         description:
           'dragPreview + nested only, default true. A dragged row with visible descendants (an expanded folder, a tab group) carries real copies of them along inside the floating clone, at the exact offset they already sat at, so the whole block reads as one physical thing lifting together.',
       },
-      { name: 'disabled', type: 'MaybeRefOrGetter<boolean>', description: 'Turns off dragging.' },
+      {
+        name: 'disabled',
+        type: 'MaybeRefOrGetter<boolean>',
+        description: 'Turns off dragging.',
+      },
       {
         name: 'motionCss',
         type: 'MaybeRefOrGetter<boolean>',
@@ -812,7 +852,11 @@ setMode('dark')
         type: '() => boolean',
         description: "OR this into the control's own invalid prop.",
       },
-      { name: 'required', type: '() => boolean', description: 'Bind to aria-required.' },
+      {
+        name: 'required',
+        type: '() => boolean',
+        description: 'Bind to aria-required.',
+      },
       {
         name: 'disabled',
         type: '() => boolean',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -78,7 +78,7 @@
     "vite": "^8.2.1",
     "vitest": "^4.1.10",
     "vitest-browser-vue": "^2.1.0",
-    "vue": "3.6.0-rc.6",
+    "vue": "3.6.0-rc.7",
     "vue-component-type-helpers": "^3.3.10",
     "vue-tsc": "^3.3.10"
   },

--- a/packages/ui/src/classes.ts
+++ b/packages/ui/src/classes.ts
@@ -1,5 +1,5 @@
-import { inject } from 'vue'
-import type { InjectionKey } from 'vue'
+import { inject, normalizeClass } from 'vue'
+import type { InjectionKey, StyleValue } from 'vue'
 
 /**
  * Optional class post-processor, e.g. `twMerge` from `tailwind-merge`.
@@ -14,15 +14,22 @@ export const classMergerKey: InjectionKey<ClassMerger> = Symbol('ui-class-merger
 
 export type ClassValue = string | false | null | undefined
 
-export type UiPartStyle = string | Record<string, string | number>
+/** Same shape a plain Vue `:class` binding accepts — string, array, object, or any nesting of those. */
+export type UiPartClass = string | Record<string, unknown> | ClassValue[] | UiPartClass[]
+
+/** Same shape a plain Vue `:style` binding accepts (`StyleValue`) — string, object, or an array of those. */
+export type UiPartStyle = StyleValue
 
 /**
  * The shape every `ui.*` part override accepts: a plain class string (as
  * before), or an object carrying a class AND a real inline style — for
  * overrides that can't be expressed as a class alone (a live-changing
- * `transform`, a one-off custom property, ...).
+ * `transform`, a one-off custom property, ...). Both `class` and `style`
+ * accept anything a plain Vue `:class`/`:style` binding would (arrays,
+ * objects, nested combinations), normalized the same way Vue's own compiler
+ * normalizes a template binding.
  */
-export type UiPartValue = string | { class?: string; style?: UiPartStyle }
+export type UiPartValue = string | { class?: UiPartClass; style?: UiPartStyle }
 
 /**
  * Join internal part classes with consumer `ui.*` overrides, routed through
@@ -48,7 +55,14 @@ export function splitUiPart(value: UiPartValue | undefined): {
   class: ClassValue
   style: UiPartStyle | undefined
 } {
-  if (value != null && typeof value === 'object') return { class: value.class, style: value.style }
+  // normalizeClass handles anything a plain `:class` binding would (array, object, nesting) the
+  // same way Vue's own compiler does — cx()'s own merge only ever sees a plain string from here.
+  if (value != null && typeof value === 'object') {
+    return {
+      class: value.class !== undefined ? normalizeClass(value.class) : undefined,
+      style: value.style,
+    }
+  }
   return { class: value, style: undefined }
 }
 

--- a/packages/ui/src/components/Accordion/Accordion.vue
+++ b/packages/ui/src/components/Accordion/Accordion.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
+  <div ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
     <slot />
   </div>
 </template>

--- a/packages/ui/src/components/AccordionItem/AccordionItem.vue
+++ b/packages/ui/src/components/AccordionItem/AccordionItem.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    v-bind="attrs"
     :class="itemPart.class"
     :style="itemPart.style"
     :data-motion="ctx.motionCss() ? undefined : 'off'"
+    v-bind="attrs"
   >
     <h3 :class="headerPart.class" :style="headerPart.style">
       <button

--- a/packages/ui/src/components/Avatar/Avatar.vue
+++ b/packages/ui/src/components/Avatar/Avatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <span ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
+  <span ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
     <span class="ui-avatar-frame">
       <span :class="fallbackPart.class" :style="fallbackPart.style">
         <slot>{{ initials }}</slot>

--- a/packages/ui/src/components/AvatarGroup/AvatarGroup.vue
+++ b/packages/ui/src/components/AvatarGroup/AvatarGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
+  <div ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
     <slot />
     <Avatar
       v-if="overflowCount > 0"

--- a/packages/ui/src/components/Badge/Badge.vue
+++ b/packages/ui/src/components/Badge/Badge.vue
@@ -1,5 +1,5 @@
 <template>
-  <span ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
+  <span ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
     <span v-if="!dot" :key="count" :class="contentClass" :style="contentStyle()">
       <slot>{{ display }}</slot>
     </span>

--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.vue
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.vue
@@ -1,10 +1,10 @@
 <template>
   <nav
     ref="root"
-    v-bind="attrs"
     :aria-label="ariaLabel"
     :class="rootPart.class"
     :style="rootPart.style"
+    v-bind="attrs"
   >
     <ol v-scroll-mask="wrap ? false : 'x'" :class="listPart.class" :style="listPart.style">
       <template v-if="items">

--- a/packages/ui/src/components/BreadcrumbSeparator/BreadcrumbSeparator.vue
+++ b/packages/ui/src/components/BreadcrumbSeparator/BreadcrumbSeparator.vue
@@ -1,5 +1,5 @@
 <template>
-  <li ref="root" v-bind="attrs" aria-hidden="true" :class="rootPart.class" :style="rootPart.style">
+  <li ref="root" aria-hidden="true" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
     <slot>
       <svg viewBox="0 0 16 16" width="14" height="14" fill="none">
         <path

--- a/packages/ui/src/components/Button/Button.vue
+++ b/packages/ui/src/components/Button/Button.vue
@@ -18,13 +18,25 @@
           <span class="ui-loader" />
         </slot>
       </span>
-      <span v-if="$slots.leading" class="ui-button-leading" aria-hidden="true">
+      <span
+        v-if="$slots.leading"
+        :class="leadingPart.class"
+        :style="leadingPart.style"
+        aria-hidden="true"
+      >
         <slot name="leading" />
       </span>
-      <span class="ui-button-content">
-        <span class="ui-button-label"><slot :loading="isLoading" :el="el" :run="run" /></span>
+      <span :class="contentPart.class" :style="contentPart.style">
+        <span :class="labelPart.class" :style="labelPart.style"
+          ><slot :loading="isLoading" :el="el" :run="run"
+        /></span>
       </span>
-      <span v-if="$slots.trailing" class="ui-button-trailing" aria-hidden="true">
+      <span
+        v-if="$slots.trailing"
+        :class="trailingPart.class"
+        :style="trailingPart.style"
+        aria-hidden="true"
+      >
         <slot name="trailing" />
       </span>
     </component>
@@ -51,13 +63,25 @@
         <span class="ui-loader" />
       </slot>
     </span>
-    <span v-if="$slots.leading" class="ui-button-leading" aria-hidden="true">
+    <span
+      v-if="$slots.leading"
+      :class="leadingPart.class"
+      :style="leadingPart.style"
+      aria-hidden="true"
+    >
       <slot name="leading" />
     </span>
-    <span class="ui-button-content">
-      <span class="ui-button-label"><slot :loading="isLoading" :el="el" :run="run" /></span>
+    <span :class="contentPart.class" :style="contentPart.style">
+      <span :class="labelPart.class" :style="labelPart.style"
+        ><slot :loading="isLoading" :el="el" :run="run"
+      /></span>
     </span>
-    <span v-if="$slots.trailing" class="ui-button-trailing" aria-hidden="true">
+    <span
+      v-if="$slots.trailing"
+      :class="trailingPart.class"
+      :style="trailingPart.style"
+      aria-hidden="true"
+    >
       <slot name="trailing" />
     </span>
   </component>
@@ -115,7 +139,18 @@ const props = withDefaults(
     as?: string
     /** Where the `#badge` slot wrapper sits relative to the button. */
     badgePlacement?: 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end'
-    ui?: Partial<{ root: UiPartValue; badge: UiPartValue }>
+    ui?: Partial<{
+      root: UiPartValue
+      /** Wraps the `#leading` slot — carries the default gap to the label; zero it here to close the gap instead of margin-hacking the slot content. */
+      leading: UiPartValue
+      /** Wraps the `#trailing` slot — same default gap as `leading`, mirrored. */
+      trailing: UiPartValue
+      /** Wraps the label content (default slot) — `display: inline-block` by default; override for e.g. an icon-above-label stacked layout. */
+      content: UiPartValue
+      /** The label itself, nested one level inside `content`. */
+      label: UiPartValue
+      badge: UiPartValue
+    }>
   }>(),
   {
     loading: false,
@@ -224,6 +259,10 @@ const rootPart = computed(() =>
   ),
 )
 const badgePart = computed(() => resolveUiPart(cx, themedUi()?.badge, 'ui-button-badge'))
+const leadingPart = computed(() => resolveUiPart(cx, themedUi()?.leading, 'ui-button-leading'))
+const trailingPart = computed(() => resolveUiPart(cx, themedUi()?.trailing, 'ui-button-trailing'))
+const contentPart = computed(() => resolveUiPart(cx, themedUi()?.content, 'ui-button-content'))
+const labelPart = computed(() => resolveUiPart(cx, themedUi()?.label, 'ui-button-label'))
 
 defineExpose({ el, loading: isLoading, run })
 </script>

--- a/packages/ui/src/components/ButtonGroup/ButtonGroup.vue
+++ b/packages/ui/src/components/ButtonGroup/ButtonGroup.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     role="group"
     :aria-label="ariaLabel"
     :class="rootPart.class"
     :style="rootPart.style"
+    v-bind="attrs"
   >
     <slot />
   </div>

--- a/packages/ui/src/components/Card/Card.vue
+++ b/packages/ui/src/components/Card/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="as" ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
+  <component :is="as" ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
     <header
       v-if="title || description || $slots.header"
       :class="headerPart.class"

--- a/packages/ui/src/components/Checkbox/Checkbox.vue
+++ b/packages/ui/src/components/Checkbox/Checkbox.vue
@@ -1,11 +1,11 @@
 <template>
   <label
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
     :data-invalid="isInvalid || undefined"
+    v-bind="attrs"
   >
     <span :class="controlClass">
       <input

--- a/packages/ui/src/components/Chip/Chip.vue
+++ b/packages/ui/src/components/Chip/Chip.vue
@@ -1,10 +1,10 @@
 <template>
   <span
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-disabled="disabled || undefined"
+    v-bind="attrs"
   >
     <span :class="labelPart.class" :style="labelPart.style"
       ><slot>{{ label }}</slot></span

--- a/packages/ui/src/components/Collapsible/Collapsible.vue
+++ b/packages/ui/src/components/Collapsible/Collapsible.vue
@@ -1,10 +1,10 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
+    v-bind="attrs"
   >
     <span
       ref="triggerWrapper"
@@ -23,7 +23,7 @@
       :data-state="collapseState"
       :aria-hidden="collapseState === 'closed' ? 'true' : undefined"
     >
-      <div class="ui-collapsible-body">
+      <div :class="bodyPart.class" :style="bodyPart.style">
         <slot />
       </div>
     </div>
@@ -50,7 +50,7 @@ const props = withDefaults(
     disabled?: boolean
     /** `false` skips transitions; use exposed `panelEl` for custom motion. */
     motionCss?: boolean
-    ui?: Partial<{ root: UiPartValue; trigger: UiPartValue; panel: UiPartValue }>
+    ui?: Partial<{ root: UiPartValue; trigger: UiPartValue; panel: UiPartValue; body: UiPartValue }>
   }>(),
   { disabled: false, motionCss: true },
 )
@@ -106,6 +106,7 @@ const rootPart = computed(() =>
 )
 const triggerPart = computed(() => resolveUiPart(cx, themedUi()?.trigger, 'ui-collapsible-trigger'))
 const panelPart = computed(() => resolveUiPart(cx, themedUi()?.panel, 'ui-collapsible-panel'))
+const bodyPart = computed(() => resolveUiPart(cx, themedUi()?.body, 'ui-collapsible-body'))
 
 defineExpose({ el: root, panelEl: panel })
 </script>

--- a/packages/ui/src/components/DataTable/DataTable.vue
+++ b/packages/ui/src/components/DataTable/DataTable.vue
@@ -1,10 +1,10 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     class="ui-datatable"
     :class="rootClasses"
     :data-stacked="stacked ? '' : undefined"
+    v-bind="attrs"
   >
     <div v-if="$slots.toolbar" class="ui-datatable-toolbar">
       <slot name="toolbar" :selected="selected" :count="sortedData.length" />

--- a/packages/ui/src/components/Dial/Dial.vue
+++ b/packages/ui/src/components/Dial/Dial.vue
@@ -1,13 +1,13 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="[dialRootStyle, rootPart.style]"
     :data-dragging="isDragging || undefined"
     :data-bounded="isBounded || undefined"
     :data-invalid="isInvalid || undefined"
     :aria-disabled="isDisabled || undefined"
+    v-bind="attrs"
   >
     <div
       ref="dialEl"

--- a/packages/ui/src/components/Dialog/Dialog.vue
+++ b/packages/ui/src/components/Dialog/Dialog.vue
@@ -28,14 +28,14 @@
           :aria-labelledby="title ? titleId : undefined"
           :aria-describedby="description ? descriptionId : undefined"
           :class="panelPart.class"
-          :style="[panelStyle, panelPart.style]"
+          :style="[panelPart.style, panelStyle]"
           v-bind="$attrs"
         >
           <button
             v-if="maximizable"
             type="button"
-            class="ui-dialog-maximize"
-            :style="maximizeStyle"
+            :class="maximizePart.class"
+            :style="[maximizeStyle, maximizePart.style]"
             :aria-label="maximized ? messages.dialog.restore : messages.dialog.maximize"
             @click="toggleMaximize"
           >
@@ -68,8 +68,8 @@
           <button
             v-if="showClose"
             type="button"
-            class="ui-dialog-close"
-            :style="closeStyle"
+            :class="closePart.class"
+            :style="[closeStyle, closePart.style]"
             :aria-label="messages.dialog.close"
             @click="requestClose('trigger', $event)"
           >
@@ -178,6 +178,8 @@ export interface DialogProps {
     description: UiPartValue
     body: UiPartValue
     footer: UiPartValue
+    maximize: UiPartValue
+    close: UiPartValue
   }>
 }
 </script>
@@ -300,6 +302,9 @@ const overlayStyle = {
   background: 'var(--ui-overlay, rgb(0 0 0 / 0.4))',
 } as const
 // Pin panel to px before maximizing (CSS can't transition auto); only non-maximized height is auto.
+// Applied AFTER panelPart.style in the template (see :style below) so a consumer's own custom
+// width/height (typically physical properties) can never permanently defeat maximize's logical
+// inlineSize/blockSize — same-axis logical vs. physical conflicts resolve by declaration order.
 const naturalPanelSize = ref<{ width: number; height: number } | null>(null)
 const panelStyle = computed<Record<string, string | undefined>>(() => {
   const base: Record<string, string | undefined> = {
@@ -392,5 +397,7 @@ const descriptionPart = computed(() =>
 )
 const bodyPart = computed(() => resolveUiPart(cx, themedUi()?.body, 'ui-dialog-body'))
 const footerPart = computed(() => resolveUiPart(cx, themedUi()?.footer, 'ui-dialog-footer'))
+const maximizePart = computed(() => resolveUiPart(cx, themedUi()?.maximize, 'ui-dialog-maximize'))
+const closePart = computed(() => resolveUiPart(cx, themedUi()?.close, 'ui-dialog-close'))
 defineExpose({ panelEl, isClosing, close, cancelClose, maximized })
 </script>

--- a/packages/ui/src/components/Dock/Dock.vue
+++ b/packages/ui/src/components/Dock/Dock.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     ref="rootEl"
-    v-bind="attrs"
     role="toolbar"
     :aria-orientation="orientation === 'vertical' ? 'vertical' : undefined"
     :class="rootPart.class"
@@ -9,6 +8,7 @@
     :data-orientation="orientation"
     @pointermove="onPointerMove"
     @pointerleave="onPointerLeave"
+    v-bind="attrs"
   >
     <button
       v-for="(item, index) in items"

--- a/packages/ui/src/components/Kbd/Kbd.vue
+++ b/packages/ui/src/components/Kbd/Kbd.vue
@@ -1,5 +1,5 @@
 <template>
-  <kbd ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style"><slot /></kbd>
+  <kbd ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs"><slot /></kbd>
 </template>
 
 <!--

--- a/packages/ui/src/components/Knob/Knob.vue
+++ b/packages/ui/src/components/Knob/Knob.vue
@@ -1,12 +1,12 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="[knobStyle, rootPart.style]"
     :data-dragging="isDragging || undefined"
     :data-invalid="isInvalid || undefined"
     :aria-disabled="isDisabled || undefined"
+    v-bind="attrs"
   >
     <div
       ref="dialEl"

--- a/packages/ui/src/components/Loader/Loader.vue
+++ b/packages/ui/src/components/Loader/Loader.vue
@@ -1,12 +1,12 @@
 <template>
   <span
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="[rootStyle, rootPart.style]"
     :role="label ? 'status' : undefined"
     :aria-labelledby="label ? labelId : undefined"
     :aria-hidden="label ? undefined : 'true'"
+    v-bind="attrs"
   >
     <span v-if="label" :id="labelId" class="ui-loader-label">{{ label }}</span>
   </span>

--- a/packages/ui/src/components/Menu/Menu.vue
+++ b/packages/ui/src/components/Menu/Menu.vue
@@ -85,7 +85,9 @@
                     </span>
                   </slot>
                 </component>
-                <!-- Teleported to ancestor to stay in same DOM subtree for outside-click detection. -->
+                <!-- Teleported to ancestor to stay in same DOM subtree for outside-click detection.
+                     Forwards #item so a custom row override keeps applying at every nesting depth
+                     instead of silently reverting to the default row past the first submenu level. -->
                 <Menu
                   v-if="entry.items && positionerEl"
                   :items="entry.items"
@@ -99,7 +101,11 @@
                   @active="(value) => onChildActive(i, value)"
                   @mouseenter="onSubmenuPanelMouseEnter(i)"
                   @mouseleave="onSubmenuPanelMouseLeave(i)"
-                />
+                >
+                  <template v-if="$slots.item" #item="{ item: nestedItem }">
+                    <slot name="item" :item="nestedItem as T" />
+                  </template>
+                </Menu>
               </template>
             </template>
           </div>
@@ -150,7 +156,9 @@ export interface MenuItemData {
   /**
    * Nested rows render as submenu triggers (opens on hover-intent, click,
    * Enter/Space, or ArrowRight). Custom item types are not available at
-   * nested levels.
+   * nested levels. In `MenuList` (no overlay/submenus there), this instead
+   * makes the row itself an inert group label with its own `items` flattened
+   * in beneath it — see `MenuList`'s `#item` slot's `isGroup` prop.
    */
   items?: ReadonlyArray<MenuEntry<MenuItemData>>
   /** Row tag — default `'button'`, or `'a'`/`'RouterLink'` for a real link (same `as`/`attrs` convention as `BreadcrumbItem`). Ignored when `items` is set. */

--- a/packages/ui/src/components/MenuList/MenuList.vue
+++ b/packages/ui/src/components/MenuList/MenuList.vue
@@ -1,10 +1,10 @@
 <template>
   <nav
     ref="list"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     @keydown="onKeydown"
+    v-bind="attrs"
   >
     <div
       v-if="hasActiveMatch"
@@ -25,7 +25,7 @@
         :class="rowClass(row, 'group')"
         :style="[indentStyle(row.depth), itemPart.style]"
       >
-        <slot name="item" :item="row.entry as T">
+        <slot name="item" :item="row.entry as T" :is-group="true">
           <span v-if="row.entry.icon" class="ui-menu-list-item-icon">
             <component :is="row.entry.icon" />
           </span>
@@ -45,7 +45,7 @@
         :style="[indentStyle(row.depth), itemPart.style]"
         v-bind="row.entry.attrs"
       >
-        <slot name="item" :item="row.entry as T">
+        <slot name="item" :item="row.entry as T" :is-group="false">
           <span v-if="row.entry.icon" class="ui-menu-list-item-icon">
             <component :is="row.entry.icon" />
           </span>
@@ -106,8 +106,12 @@ const emit = defineEmits<{
 }>()
 
 defineSlots<{
-  /** Override one row's content while keeping its behavior. Fires for selectable rows and group labels. */
-  item(props: { item: T }): unknown
+  /**
+   * Override one row's content while keeping its behavior. Fires for selectable rows and
+   * group labels alike — `isGroup` tells which: a `true` row is inert (its own `items`
+   * rendered as children beneath it, not a click target) rather than selectable.
+   */
+  item(props: { item: T; isGroup: boolean }): unknown
 }>()
 
 function isSeparator(entry: MenuEntry<MenuItemData>): entry is MenuSeparator {

--- a/packages/ui/src/components/Message/Message.vue
+++ b/packages/ui/src/components/Message/Message.vue
@@ -4,11 +4,11 @@
       v-if="forceMount || open"
       v-show="open"
       ref="root"
-      v-bind="attrs"
       :class="rootPart.class"
       :style="rootPart.style"
       :role="resolvedRole"
       :data-state="isClosing ? 'closing' : 'open'"
+      v-bind="attrs"
     >
       <span v-if="showIcon" :class="iconPart.class" :style="iconPart.style" aria-hidden="true">
         <slot name="icon">
@@ -21,7 +21,7 @@
           <slot />
         </div>
       </div>
-      <div v-if="$slots.actions" class="ui-message-actions">
+      <div v-if="$slots.actions" :class="actionsPart.class" :style="actionsPart.style">
         <slot name="actions" />
       </div>
       <button
@@ -78,6 +78,7 @@ export interface MessageProps {
     content: UiPartValue
     title: UiPartValue
     description: UiPartValue
+    actions: UiPartValue
     close: UiPartValue
   }>
 }
@@ -199,6 +200,7 @@ const descriptionPart = computed(() =>
   resolveUiPart(cx, themedUi()?.description, 'ui-message-description'),
 )
 const closePart = computed(() => resolveUiPart(cx, themedUi()?.close, 'ui-message-close'))
+const actionsPart = computed(() => resolveUiPart(cx, themedUi()?.actions, 'ui-message-actions'))
 
 defineExpose({ el: root, close, isClosing, cancelClose })
 </script>

--- a/packages/ui/src/components/OtpInput/OtpInput.vue
+++ b/packages/ui/src/components/OtpInput/OtpInput.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
     :data-focus-visible="focusVisible || undefined"
+    v-bind="attrs"
   >
     <div class="ui-otp-cells" aria-hidden="true">
       <span

--- a/packages/ui/src/components/Pagination/Pagination.vue
+++ b/packages/ui/src/components/Pagination/Pagination.vue
@@ -1,15 +1,16 @@
 <template>
   <nav
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :aria-label="messages.pagination.label"
+    v-bind="attrs"
   >
     <ul ref="list" :class="listPart.class" :style="listPart.style">
       <span class="ui-pagination-indicator" aria-hidden="true" :style="indicator.style.value" />
       <li>
         <Button
-          class="ui-pagination-nav-button"
+          :class="navButtonPart.class"
+          :style="navButtonPart.style"
           icon
           size="sm"
           variant="ghost"
@@ -31,7 +32,8 @@
       </li>
       <li>
         <Button
-          class="ui-pagination-nav-button"
+          :class="navButtonPart.class"
+          :style="navButtonPart.style"
           icon
           size="sm"
           variant="ghost"
@@ -53,13 +55,17 @@
       </li>
 
       <li v-for="item in pageItems" :key="item">
-        <span v-if="typeof item !== 'number'" class="ui-pagination-ellipsis" aria-hidden="true"
+        <span
+          v-if="typeof item !== 'number'"
+          :class="ellipsisPart.class"
+          :style="ellipsisPart.style"
+          aria-hidden="true"
           >…</span
         >
         <Button
           v-else
-          class="ui-pagination-page-button"
-          :class="{ 'ui-pagination-page-button--active': item === page }"
+          :class="pageButtonPart(item === page).class"
+          :style="pageButtonPart(item === page).style"
           icon
           size="sm"
           variant="ghost"
@@ -74,7 +80,8 @@
 
       <li>
         <Button
-          class="ui-pagination-nav-button"
+          :class="navButtonPart.class"
+          :style="navButtonPart.style"
           icon
           size="sm"
           variant="ghost"
@@ -96,7 +103,8 @@
       </li>
       <li>
         <Button
-          class="ui-pagination-nav-button"
+          :class="navButtonPart.class"
+          :style="navButtonPart.style"
           icon
           size="sm"
           variant="ghost"
@@ -120,7 +128,8 @@
 
     <Select
       v-if="pageSizeOptions && pageSizeOptions.length > 0"
-      class="ui-pagination-size-select"
+      :class="sizeSelectPart.class"
+      :style="sizeSelectPart.style"
       size="sm"
       :items="pageSizeItems"
       :model-value="pageSize"
@@ -234,4 +243,21 @@ const themedUi = useThemedUi(
 )
 const rootPart = computed(() => resolveUiPart(cx, themedUi()?.root, 'ui-pagination'))
 const listPart = computed(() => resolveUiPart(cx, themedUi()?.list, 'ui-pagination-list'))
+const navButtonPart = computed(() =>
+  resolveUiPart(cx, themedUi()?.button, 'ui-pagination-nav-button'),
+)
+function pageButtonPart(active: boolean) {
+  return resolveUiPart(
+    cx,
+    themedUi()?.button,
+    'ui-pagination-page-button',
+    active && 'ui-pagination-page-button--active',
+  )
+}
+const ellipsisPart = computed(() =>
+  resolveUiPart(cx, themedUi()?.ellipsis, 'ui-pagination-ellipsis'),
+)
+const sizeSelectPart = computed(() =>
+  resolveUiPart(cx, themedUi()?.sizeSelect, 'ui-pagination-size-select'),
+)
 </script>

--- a/packages/ui/src/components/Progress/Progress.vue
+++ b/packages/ui/src/components/Progress/Progress.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     role="progressbar"
@@ -10,6 +9,7 @@
     :aria-valuenow="indeterminate ? undefined : clampedValue"
     :aria-label="label"
     :data-state="state"
+    v-bind="attrs"
   >
     <div :class="trackPart.class" :style="trackPart.style">
       <div ref="fill" :class="fillPart.class" :style="[fillStyle, fillPart.style]" />

--- a/packages/ui/src/components/PullToRefresh/PullToRefresh.css
+++ b/packages/ui/src/components/PullToRefresh/PullToRefresh.css
@@ -2,6 +2,10 @@
   /* Pull to refresh: usePullToRefresh owns pullDistance and zone block-size. */
   .ui-pull-to-refresh-root {
     position: relative;
+  }
+  /* Only when this root is itself the scroll box (no external `scrollEl`) — a consumer
+     dropping this into an already-scrollable layout keeps their own overflow untouched. */
+  .ui-pull-to-refresh-root[data-self-scroll] {
     overflow-y: auto;
     overscroll-behavior-y: contain;
   }

--- a/packages/ui/src/components/PullToRefresh/PullToRefresh.vue
+++ b/packages/ui/src/components/PullToRefresh/PullToRefresh.vue
@@ -1,10 +1,11 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="state"
+    :data-self-scroll="ownsScroll ? '' : undefined"
+    v-bind="attrs"
   >
     <div
       ref="zoneEl"
@@ -62,7 +63,11 @@ export interface PullToRefreshProps {
   threshold?: number
   /** Maximum pull distance (in pixels) allowed before clamping. */
   maxPull?: number
-  /** Detects gestures on this element instead of the root. Defaults to the root. */
+  /**
+   * Detects gestures on this element instead of the root, for dropping into an existing
+   * scrollable layout as a thin wrapper. Defaults to the root, which then owns scrolling
+   * itself (`overflow-y: auto`); passing one leaves the root's own overflow untouched.
+   */
   scrollEl?: HTMLElement | { el: HTMLElement | null } | null
   ui?: Partial<{
     root: UiPartValue
@@ -112,9 +117,10 @@ function reducedMotion(): boolean {
 }
 
 const root = useTemplateRef<HTMLElement>('root')
-const scrollEl = computed(() =>
-  props.scrollEl !== undefined ? unwrapEl(props.scrollEl) : root.value,
-)
+// Own scrolling only when the consumer hasn't handed us an existing scroll box — dropping this
+// into an already-scrollable layout shouldn't force that layout to restructure around our root.
+const ownsScroll = computed(() => props.scrollEl === undefined)
+const scrollEl = computed(() => (ownsScroll.value ? root.value : unwrapEl(props.scrollEl)))
 
 const messages = useUiMessages()
 

--- a/packages/ui/src/components/Radio/Radio.vue
+++ b/packages/ui/src/components/Radio/Radio.vue
@@ -1,10 +1,10 @@
 <template>
   <label
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
+    v-bind="attrs"
   >
     <span class="ui-radio-frame">
       <input

--- a/packages/ui/src/components/RadioGroup/RadioGroup.vue
+++ b/packages/ui/src/components/RadioGroup/RadioGroup.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     role="radiogroup"
     :id="fieldControl.id"
     :class="rootPart.class"
@@ -11,6 +10,7 @@
     :aria-describedby="fieldControl.describedBy()"
     :aria-invalid="isInvalid || undefined"
     :aria-required="fieldControl.required() || undefined"
+    v-bind="attrs"
   >
     <slot />
   </div>

--- a/packages/ui/src/components/Rating/Rating.vue
+++ b/packages/ui/src/components/Rating/Rating.vue
@@ -1,9 +1,8 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
-    :style="[rootPart.style, attrs.style as never]"
+    :style="rootPart.style"
     role="slider"
     :tabindex="isDisabled ? -1 : 0"
     aria-orientation="horizontal"
@@ -25,6 +24,7 @@
     @keydown="onKeydown"
     @focus="fieldControl.onFocus"
     @blur="fieldControl.onBlur"
+    v-bind="attrs"
   >
     <span :key="committedKey" class="ui-rating-track">
       <span

--- a/packages/ui/src/components/Resizable/Resizable.vue
+++ b/packages/ui/src/components/Resizable/Resizable.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="[sizeStyle, rootPart.style]"
     :data-resizing="isDragging || undefined"
     :aria-disabled="disabled || undefined"
+    v-bind="attrs"
   >
     <slot />
     <div

--- a/packages/ui/src/components/ScrollArea/ScrollArea.vue
+++ b/packages/ui/src/components/ScrollArea/ScrollArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
+  <div ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
     <div
       ref="viewport"
       :class="viewportPart.class"

--- a/packages/ui/src/components/SelectButton/SelectButton.vue
+++ b/packages/ui/src/components/SelectButton/SelectButton.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :role="multiple ? 'group' : 'radiogroup'"
     :id="fieldControl.id"
     :class="rootPart.class"
@@ -11,6 +10,7 @@
     :aria-describedby="fieldControl.describedBy()"
     :aria-invalid="isInvalid || undefined"
     :aria-required="fieldControl.required() || undefined"
+    v-bind="attrs"
   >
     <label
       v-for="item in items"

--- a/packages/ui/src/components/Separator/Separator.vue
+++ b/packages/ui/src/components/Separator/Separator.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     role="separator"
     :aria-orientation="ariaOrientation"
+    v-bind="attrs"
   >
     <span
       v-if="$slots.default"

--- a/packages/ui/src/components/Skeleton/Skeleton.vue
+++ b/packages/ui/src/components/Skeleton/Skeleton.vue
@@ -1,10 +1,10 @@
 <template>
   <span
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     aria-hidden="true"
+    v-bind="attrs"
   >
     <span v-if="$slots.default" class="ui-skeleton-content"><slot /></span>
   </span>

--- a/packages/ui/src/components/Slider/Slider.vue
+++ b/packages/ui/src/components/Slider/Slider.vue
@@ -1,13 +1,13 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="[sliderStyle, rootPart.style]"
     :data-dragging="isDragging || undefined"
     :data-range="isRangeModel || undefined"
     :data-invalid="isInvalid || undefined"
     :aria-disabled="isDisabled || undefined"
+    v-bind="attrs"
   >
     <div
       ref="trackEl"

--- a/packages/ui/src/components/Sortable/Sortable.vue
+++ b/packages/ui/src/components/Sortable/Sortable.vue
@@ -1,7 +1,6 @@
 <template>
   <ul
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-motion="motionCss ? undefined : 'off'"
@@ -9,6 +8,7 @@
     :data-invalid-drop="isGrabbed && !isValidDrop ? '' : undefined"
     :data-pending="isPending ? '' : undefined"
     :data-drop-target="isForeignDropTarget ? '' : undefined"
+    v-bind="attrs"
   >
     <li
       v-for="(item, index) in items"

--- a/packages/ui/src/components/SwipeToReveal/SwipeToReveal.vue
+++ b/packages/ui/src/components/SwipeToReveal/SwipeToReveal.vue
@@ -1,13 +1,13 @@
 <template>
   <div
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-side="side"
     :data-dragging="isDragging || undefined"
     :data-motion="motionCss ? undefined : 'off'"
     :aria-disabled="disabled || undefined"
+    v-bind="attrs"
   >
     <div ref="actionsEl" :class="actionsPart.class" :style="actionsPart.style">
       <slot name="actions" :open="open" :close="close" />

--- a/packages/ui/src/components/Switch/Switch.vue
+++ b/packages/ui/src/components/Switch/Switch.vue
@@ -1,11 +1,11 @@
 <template>
   <label
     ref="root"
-    v-bind="attrs"
     :class="rootPart.class"
     :style="rootPart.style"
     :data-state="dataState"
     :data-invalid="isInvalid || undefined"
+    v-bind="attrs"
   >
     <span class="ui-switch-control">
       <input

--- a/packages/ui/src/components/Tabs/Tabs.vue
+++ b/packages/ui/src/components/Tabs/Tabs.vue
@@ -1,12 +1,12 @@
 <template>
   <div
     ref="list"
-    v-bind="attrs"
     role="tablist"
     :aria-orientation="props.orientation === 'vertical' ? 'vertical' : undefined"
     :class="listPart.class"
     :style="listPart.style"
     @keydown="onKeydown"
+    v-bind="attrs"
   >
     <slot
       :active="active"

--- a/packages/ui/src/components/Tag/Tag.vue
+++ b/packages/ui/src/components/Tag/Tag.vue
@@ -1,7 +1,9 @@
 <template>
-  <span ref="root" v-bind="attrs" :class="rootPart.class" :style="rootPart.style">
-    <span v-if="$slots.icon" class="ui-tag-icon" aria-hidden="true"><slot name="icon" /></span>
-    <span class="ui-tag-label"><slot /></span>
+  <span ref="root" :class="rootPart.class" :style="rootPart.style" v-bind="attrs">
+    <span v-if="$slots.icon" :class="iconPart.class" :style="iconPart.style" aria-hidden="true"
+      ><slot name="icon"
+    /></span>
+    <span :class="labelPart.class" :style="labelPart.style"><slot /></span>
   </span>
 </template>
 
@@ -23,7 +25,7 @@ const props = withDefaults(
     size?: 'sm' | 'md'
     /** Fully pill-rounded instead of the default small label corners. */
     pill?: boolean
-    ui?: Partial<{ root: UiPartValue; icon: UiPartValue }>
+    ui?: Partial<{ root: UiPartValue; icon: UiPartValue; label: UiPartValue }>
   }>(),
   { variant: 'muted', size: 'md', pill: false },
 )
@@ -50,6 +52,8 @@ const rootPart = computed(() =>
     props.pill && 'ui-tag--pill',
   ),
 )
+const iconPart = computed(() => resolveUiPart(cx, themedUi()?.icon, 'ui-tag-icon'))
+const labelPart = computed(() => resolveUiPart(cx, themedUi()?.label, 'ui-tag-label'))
 
 defineExpose({ el: root })
 </script>

--- a/packages/ui/src/components/Textarea/Textarea.css
+++ b/packages/ui/src/components/Textarea/Textarea.css
@@ -82,9 +82,14 @@
     grid-area: bottom;
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 0.5rem;
     margin-block-start: 0.5rem;
+  }
+  /* margin-inline-start: auto, not space-between on the parent — with only
+     #bottom-end provided, space-between has a single flex child and pins it
+     to the start instead of the end. */
+  .ui-textarea-bottom-end {
+    margin-inline-start: auto;
   }
   /* Same pointer/keyboard focus split as .ui-input above. */
   .ui-textarea:focus-within {

--- a/packages/ui/src/components/Toolbar/Toolbar.vue
+++ b/packages/ui/src/components/Toolbar/Toolbar.vue
@@ -1,12 +1,12 @@
 <template>
   <div
     ref="list"
-    v-bind="attrs"
     role="toolbar"
     :aria-orientation="orientation === 'vertical' ? 'vertical' : undefined"
     :class="rootPart.class"
     :style="rootPart.style"
     @keydown="onKeydown"
+    v-bind="attrs"
   >
     <div v-if="slots.start || slots.default" :class="groupPart.class" :style="groupPart.style">
       <slot name="start" />

--- a/packages/ui/src/components/Tour/Tour.css
+++ b/packages/ui/src/components/Tour/Tour.css
@@ -4,9 +4,11 @@
     inset: 0;
     z-index: var(--ui-z-tour, 52);
     background: var(--ui-overlay);
-    transition:
-      opacity var(--ui-duration-exit) var(--ui-ease-out),
-      clip-path var(--ui-duration-drawer) var(--ui-ease-drawer);
+    /* Only opacity transitions in CSS. The cutout's step-to-step glide is driven in JS
+       (TourSpotlight.vue) — a CSS transition of `clip-path: path()` on this fixed, full-viewport
+       layer makes Chromium's compositor rasterise it clipped to a collapsed corner for the whole
+       transition, then snap right when it ends. */
+    transition: opacity var(--ui-duration-exit) var(--ui-ease-out);
   }
   .ui-tour-spotlight-enter-active {
     transition: opacity var(--ui-duration-enter) var(--ui-ease-out);

--- a/packages/ui/src/components/Tour/TourSpotlight.vue
+++ b/packages/ui/src/components/Tour/TourSpotlight.vue
@@ -6,11 +6,7 @@
         v-show="active"
         ref="overlay"
         :class="overlayPart.class"
-        :style="[
-          { clipPath, position: contained ? 'absolute' : undefined },
-          instant && { transitionProperty: 'opacity' },
-          overlayPart.style,
-        ]"
+        :style="[{ clipPath, position: contained ? 'absolute' : undefined }, overlayPart.style]"
         aria-hidden="true"
       />
     </Transition>
@@ -27,7 +23,7 @@ export interface TourSpotlightProps {
   padding?: number
   /** Cutout corner radius, in pixels. Clamped so it never exceeds half the padded box's own width/height. */
   radius?: number
-  /** Drops the clip-path transition so the cutout tracks 1:1 instead of chasing — for while a scroll driven by the same target change is in flight, so it doesn't lag a beat behind every scroll frame. */
+  /** Snaps the cutout to the target 1:1 instead of gliding to it — for while a scroll driven by the same target change is in flight, so it doesn't lag a beat behind every scroll frame. */
   instant?: boolean
   forceMount?: boolean
   teleportTo?: string | HTMLElement
@@ -39,10 +35,17 @@ export interface TourSpotlightProps {
 
 <!--
   Cutout via `clip-path: path(evenodd, ...)`, not an SVG mask or the box-shadow spread trick:
-  clip-path is compositor-accelerated (unlike box-shadow) and affects hit-testing (unlike mask),
-  so the cutout region is natively click-through with no separate click-catcher element. The path
-  always emits the same rounded-rect command structure (arcs even at radius 0) so the browser can
-  interpolate it smoothly between steps instead of snapping.
+  clip-path affects hit-testing (unlike mask), so the cutout region is natively click-through
+  with no separate click-catcher element, and it doesn't repaint the whole viewport every frame
+  the way an animated box-shadow spread would.
+
+  The step-to-step glide is driven here in JS (rAF), NOT a CSS `transition: clip-path`. A CSS
+  transition of `clip-path: path()` on a viewport-filling `position: fixed` layer hits a
+  compositor bug in Chromium: for the transition's whole duration the layer rasterises clipped
+  to a collapsed top-left rectangle with no visible cutout, then snaps correct when it ends.
+  Writing a fresh, static `path()` string each frame sidesteps it — the compositor never sees an
+  animating clip-path — and each frame's path is still a complete rounded-rect so there's no
+  geometry popping.
 -->
 <script setup lang="ts">
 import './Tour.css'
@@ -69,43 +72,194 @@ const overlayPart = computed(() => resolveUiPart(cx, props.ui, 'ui-tour-spotligh
 
 const clipPath = shallowRef<string | undefined>(undefined)
 
-function update() {
-  const target = props.targetEl
-  if (!target) return
-  const rect = target.getBoundingClientRect()
+/** The cutout's geometry, in the overlay's own coordinate space, before it's serialised to a path. */
+interface Cutout {
+  x: number
+  y: number
+  w: number
+  h: number
+  /** Requested corner radius — clamped against the box's own size only at serialise time. */
+  radius: number
+  /** Mask extent: viewport, or the container's own box when contained. */
+  vw: number
+  vh: number
+}
+
+function measure(): Cutout {
+  const rect = props.targetEl!.getBoundingClientRect()
   const container = props.containerEl
   const containerRect = container?.getBoundingClientRect()
   const originX = containerRect?.left ?? 0
   const originY = containerRect?.top ?? 0
   const pad = props.padding
-  const x = rect.left - originX - pad
-  const y = rect.top - originY - pad
-  const w = rect.width + pad * 2
-  const h = rect.height + pad * 2
-  const r = Math.max(0, Math.min(props.radius, w / 2, h / 2))
-  const vw = container ? container.clientWidth : window.innerWidth
-  const vh = container ? container.clientHeight : window.innerHeight
-  clipPath.value =
+  return {
+    x: rect.left - originX - pad,
+    y: rect.top - originY - pad,
+    w: rect.width + pad * 2,
+    h: rect.height + pad * 2,
+    radius: props.radius,
+    vw: container ? container.clientWidth : window.innerWidth,
+    vh: container ? container.clientHeight : window.innerHeight,
+  }
+}
+
+function toPath({ x, y, w, h, radius, vw, vh }: Cutout): string {
+  const r = Math.max(0, Math.min(radius, w / 2, h / 2))
+  return (
     `path(evenodd, "M0,0 H${vw} V${vh} H0 Z ` +
     `M${x + r},${y} H${x + w - r} A${r} ${r} 0 0 1 ${x + w},${y + r} ` +
     `V${y + h - r} A${r} ${r} 0 0 1 ${x + w - r},${y + h} ` +
     `H${x + r} A${r} ${r} 0 0 1 ${x},${y + h - r} ` +
     `V${y + r} A${r} ${r} 0 0 1 ${x + r},${y} Z")`
+  )
+}
+
+// cubic-bezier solver — Newton-Raphson on x(t), then evaluate y(t).
+function makeBezierEasing(p1x: number, p1y: number, p2x: number, p2y: number) {
+  const cx = 3 * p1x
+  const bx = 3 * (p2x - p1x) - cx
+  const ax = 1 - cx - bx
+  const cy = 3 * p1y
+  const by = 3 * (p2y - p1y) - cy
+  const ay = 1 - cy - by
+  const xAt = (t: number) => ((ax * t + bx) * t + cx) * t
+  const dxAt = (t: number) => (3 * ax * t + 2 * bx) * t + cx
+  return (x: number) => {
+    let t = x
+    for (let i = 0; i < 8; i++) {
+      const dx = xAt(t) - x
+      if (Math.abs(dx) < 1e-4) break
+      const d = dxAt(t)
+      if (Math.abs(d) < 1e-6) break
+      t -= dx / d
+    }
+    return ((ay * t + by) * t + cy) * t
+  }
+}
+// `--ui-ease-out` — a decisive smooth-out. The cutout is repositioning, not making an
+// entrance, so it wants the library's position-change curve rather than the long, settling
+// `--ui-ease-drawer` tail, which made the far sweeps in the stress test look like they crawl
+// the last stretch after visually already arriving.
+const easeGlide = makeBezierEasing(0.23, 1, 0.32, 1)
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+// Travel-aware: a nudge to a neighbouring target resolves quickly; a sweep clear across the
+// viewport earns a longer glide — but a far bound is still faster than the old flat 500ms.
+// Range/curve follow the transitions-polish doctrine for a position change (~250–400ms).
+const GLIDE_MIN_MS = 220
+const GLIDE_MAX_MS = 380
+function glideDuration(a: Cutout, b: Cutout): number {
+  const travel = Math.hypot(b.x + b.w / 2 - (a.x + a.w / 2), b.y + b.h / 2 - (a.y + a.h / 2))
+  const t = Math.min(1, travel / (Math.hypot(a.vw, a.vh) || 1))
+  return GLIDE_MIN_MS + (GLIDE_MAX_MS - GLIDE_MIN_MS) * Math.sqrt(t)
+}
+
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t
+const tween = (a: Cutout, b: Cutout, t: number): Cutout => ({
+  x: lerp(a.x, b.x, t),
+  y: lerp(a.y, b.y, t),
+  w: lerp(a.w, b.w, t),
+  h: lerp(a.h, b.h, t),
+  radius: lerp(a.radius, b.radius, t),
+  vw: lerp(a.vw, b.vw, t),
+  vh: lerp(a.vh, b.vh, t),
+})
+
+// `current` is whatever the overlay is clipped to right now (mid-glide included), so a step
+// change that lands while the last one is still gliding retargets from the real position.
+let current: Cutout | null = null
+let from: Cutout | null = null
+let to: Cutout | null = null
+let animStart = 0
+let animDuration = GLIDE_MAX_MS
+let animFrame: number | undefined
+
+function stopAnim() {
+  if (animFrame !== undefined) {
+    cancelAnimationFrame(animFrame)
+    animFrame = undefined
+  }
+  from = to = null
+}
+
+function commit(cutout: Cutout) {
+  current = cutout
+  clipPath.value = toPath(cutout)
+}
+
+function tick(now: number) {
+  animFrame = undefined
+  if (!from || !to) return
+  const p = animDuration > 0 ? Math.min(1, (now - animStart) / animDuration) : 1
+  commit(p >= 1 ? to : tween(from, to, easeGlide(p)))
+  if (p < 1) animFrame = requestAnimationFrame(tick)
+  else from = to = null
+}
+
+function update() {
+  if (!props.targetEl) return
+  const next = measure()
+  // First paint, a scroll driven by this same step change (see `instant`), or reduced motion:
+  // land on it outright. Otherwise glide from wherever the cutout currently sits.
+  if (props.instant || current === null || prefersReducedMotion()) {
+    stopAnim()
+    commit(next)
+    return
+  }
+  from = current
+  to = next
+  animStart = performance.now()
+  animDuration = glideDuration(current, next)
+  if (animFrame === undefined) animFrame = requestAnimationFrame(tick)
 }
 
 let stopAutoUpdate: (() => void) | undefined
+let pendingFrame: number | undefined
+// Tracks which overlay element already had its real first paint. A fresh v-if mount resets it
+// (and the cutout state below) so that first paint lands outright; a step change within the
+// same open session keeps it, so `update()` glides from the current cutout instead.
+let paintedOverlay: HTMLElement | null = null
 watch(
   () => [props.active, props.targetEl, overlay.value, props.containerEl] as const,
   ([active, target, overlayEl]) => {
     stopAutoUpdate?.()
     stopAutoUpdate = undefined
-    if (!active || !target || !overlayEl) return
-    stopAutoUpdate = autoUpdate(target, overlayEl, update)
+    if (pendingFrame !== undefined) {
+      cancelAnimationFrame(pendingFrame)
+      pendingFrame = undefined
+    }
+    if (!active || !target || !overlayEl) {
+      // Closed, or torn down: forget where the cutout sat so the next open snaps to its
+      // first step rather than gliding in from a stale position.
+      stopAnim()
+      current = null
+      return
+    }
+    if (paintedOverlay === overlayEl) {
+      stopAutoUpdate = autoUpdate(target, overlayEl, update)
+      return
+    }
+    // First paint of a freshly-inserted overlay: some compositors don't reflect the real cutout
+    // on a brand-new position:fixed element until a second paint forces it. Let it paint once
+    // (blank), then wire up autoUpdate on the next frame so the real value lands on paint two.
+    stopAnim()
+    current = null
+    pendingFrame = requestAnimationFrame(() => {
+      pendingFrame = undefined
+      paintedOverlay = overlayEl
+      stopAutoUpdate = autoUpdate(target, overlayEl, update)
+    })
   },
   { flush: 'post' },
 )
 
-onScopeDispose(() => stopAutoUpdate?.())
+onScopeDispose(() => {
+  stopAutoUpdate?.()
+  stopAnim()
+  if (pendingFrame !== undefined) cancelAnimationFrame(pendingFrame)
+})
 
 defineExpose({ el: overlay })
 </script>

--- a/packages/ui/src/components/shared/tokens.css
+++ b/packages/ui/src/components/shared/tokens.css
@@ -1,77 +1,106 @@
-:root {
-  --ui-primary: #18181b;
-  --ui-primary-hover: #27272a;
-  --ui-primary-contrast: #fafafa;
-  --ui-muted: #f4f4f5;
-  --ui-muted-hover: #e4e4e7;
-  --ui-danger: oklch(0.586 0.253 26);
-  --ui-danger-hover: color-mix(in oklch, var(--ui-danger) 85%, black);
-  --ui-danger-contrast: #ffffff;
-  --ui-success: oklch(71.335% 0.15901 160.899);
-  --ui-success-hover: color-mix(in oklch, var(--ui-success) 85%, black);
-  --ui-success-contrast: #ffffff;
-  --ui-warning: oklch(0.666 0.179 58.315);
-  --ui-warning-hover: color-mix(in oklch, var(--ui-warning) 85%, black);
-  --ui-warning-contrast: #ffffff;
-  --ui-info: #2563eb;
-  --ui-info-hover: #1d4ed8;
-  --ui-info-contrast: #ffffff;
-  --ui-surface: #ffffff;
-  --ui-text: #18181b;
-  --ui-text-muted: #71717a;
-  --ui-border: #e4e4e7;
-  --ui-overlay: rgb(0 0 0 / 0.4);
-  --ui-radius: 10px;
-  --ui-border-strong: #d4d4d8;
+@layer ui-components {
+  :root {
+    --ui-primary: #18181b;
+    --ui-primary-hover: #27272a;
+    --ui-primary-contrast: #fafafa;
+    --ui-muted: #f4f4f5;
+    --ui-muted-hover: #e4e4e7;
+    --ui-danger: oklch(0.586 0.253 26);
+    --ui-danger-hover: color-mix(in oklch, var(--ui-danger) 85%, black);
+    --ui-danger-contrast: #ffffff;
+    --ui-success: oklch(71.335% 0.15901 160.899);
+    --ui-success-hover: color-mix(in oklch, var(--ui-success) 85%, black);
+    --ui-success-contrast: #ffffff;
+    --ui-warning: oklch(0.666 0.179 58.315);
+    --ui-warning-hover: color-mix(in oklch, var(--ui-warning) 85%, black);
+    --ui-warning-contrast: #ffffff;
+    --ui-info: #2563eb;
+    --ui-info-hover: #1d4ed8;
+    --ui-info-contrast: #ffffff;
+    --ui-surface: #ffffff;
+    --ui-text: #18181b;
+    --ui-text-muted: #71717a;
+    --ui-border: #e4e4e7;
+    --ui-overlay: rgb(0 0 0 / 0.4);
+    --ui-radius: 10px;
+    --ui-border-strong: #d4d4d8;
 
-  /* Below dialog: a drag preview floats over page content, never over a modal. */
-  --ui-z-drag: 45;
-  --ui-z-dialog: 50;
-  --ui-z-tour: 52;
-  --ui-z-popover: 55;
-  --ui-z-toast: 60;
-  --ui-z-tooltip: 70;
-  --ui-panel-shadow:
-    0 0 0 1px rgb(0 0 0 / 0.04), 0 8px 24px rgb(0 0 0 / 0.12), 0 24px 48px rgb(0 0 0 / 0.08);
+    /* Below dialog: a drag preview floats over page content, never over a modal. */
+    --ui-z-drag: 45;
+    --ui-z-dialog: 50;
+    --ui-z-tour: 52;
+    --ui-z-popover: 55;
+    --ui-z-toast: 60;
+    --ui-z-tooltip: 70;
+    --ui-panel-shadow:
+      0 0 0 1px rgb(0 0 0 / 0.04), 0 8px 24px rgb(0 0 0 / 0.12), 0 24px 48px rgb(0 0 0 / 0.08);
 
-  --ui-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
-  --ui-ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+    --ui-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --ui-ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
 
-  --ui-ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
-  --ui-duration-drawer: 500ms;
-  --ui-duration-press: 160ms;
-  --ui-duration-enter: 200ms;
-  --ui-duration-exit: 150ms;
-  --ui-duration-tooltip: 125ms;
-  --ui-duration-tooltip-exit: 100ms;
-  --ui-duration-toast: 400ms;
-  --ui-duration-toast-exit: 200ms;
-  --ui-duration-pulse: 1.2s;
-  --ui-ease-toast: var(--ui-ease-out);
-  --ui-toast-offset: 1rem;
-}
+    --ui-ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+    --ui-duration-drawer: 500ms;
+    --ui-duration-press: 160ms;
+    --ui-duration-enter: 200ms;
+    --ui-duration-exit: 150ms;
+    --ui-duration-tooltip: 125ms;
+    --ui-duration-tooltip-exit: 100ms;
+    --ui-duration-toast: 400ms;
+    --ui-duration-toast-exit: 200ms;
+    --ui-duration-pulse: 1.2s;
+    --ui-ease-toast: var(--ui-ease-out);
+    --ui-toast-offset: 1rem;
+  }
 
-*,
-::before,
-::after {
-  -webkit-tap-highlight-color: transparent;
-  --ui-radius-surface: min(var(--ui-radius), 1rem);
-}
+  *,
+  ::before,
+  ::after {
+    -webkit-tap-highlight-color: transparent;
+    --ui-radius-surface: min(var(--ui-radius), 1rem);
+  }
 
-@property --ui-dialog-t {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 1;
-}
+  @property --ui-dialog-t {
+    syntax: '<number>';
+    inherits: false;
+    initial-value: 1;
+  }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme='light']) {
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme='light']) {
+      --ui-primary: #fafafa;
+      --ui-primary-hover: #e4e4e7;
+      --ui-primary-contrast: #18181b;
+      --ui-muted: #27272a;
+      --ui-muted-hover: #3f3f46;
+
+      --ui-danger: oklch(0.7 0.19 26);
+      --ui-danger-hover: color-mix(in oklch, oklch(0.7 0.19 26) 85%, white);
+      --ui-danger-contrast: #ffffff;
+      --ui-success: oklch(0.75 0.17 163.225);
+      --ui-success-hover: color-mix(in oklch, oklch(0.75 0.17 163.225) 85%, white);
+      --ui-success-contrast: #ffffff;
+      --ui-warning: oklch(0.8 0.16 58.315);
+      --ui-warning-hover: color-mix(in oklch, oklch(0.8 0.16 58.315) 85%, white);
+      --ui-warning-contrast: #18181b;
+      --ui-info: #3b82f6;
+      --ui-info-hover: #2563eb;
+      --ui-info-contrast: #ffffff;
+      --ui-surface: #1f1f23;
+      --ui-text: #fafafa;
+      --ui-text-muted: #a1a1aa;
+      --ui-border: #3f3f46;
+      --ui-overlay: rgb(0 0 0 / 0.6);
+      --ui-panel-shadow: 0 0 0 1px rgb(255 255 255 / 0.08), 0 8px 24px rgb(0 0 0 / 0.5);
+      --ui-border-strong: #52525b;
+    }
+  }
+
+  :root[data-theme='dark'] {
     --ui-primary: #fafafa;
     --ui-primary-hover: #e4e4e7;
     --ui-primary-contrast: #18181b;
     --ui-muted: #27272a;
     --ui-muted-hover: #3f3f46;
-
     --ui-danger: oklch(0.7 0.19 26);
     --ui-danger-hover: color-mix(in oklch, oklch(0.7 0.19 26) 85%, white);
     --ui-danger-contrast: #ffffff;
@@ -92,31 +121,4 @@
     --ui-panel-shadow: 0 0 0 1px rgb(255 255 255 / 0.08), 0 8px 24px rgb(0 0 0 / 0.5);
     --ui-border-strong: #52525b;
   }
-}
-
-:root[data-theme='dark'] {
-  --ui-primary: #fafafa;
-  --ui-primary-hover: #e4e4e7;
-  --ui-primary-contrast: #18181b;
-  --ui-muted: #27272a;
-  --ui-muted-hover: #3f3f46;
-  --ui-danger: oklch(0.7 0.19 26);
-  --ui-danger-hover: color-mix(in oklch, oklch(0.7 0.19 26) 85%, white);
-  --ui-danger-contrast: #ffffff;
-  --ui-success: oklch(0.75 0.17 163.225);
-  --ui-success-hover: color-mix(in oklch, oklch(0.75 0.17 163.225) 85%, white);
-  --ui-success-contrast: #ffffff;
-  --ui-warning: oklch(0.8 0.16 58.315);
-  --ui-warning-hover: color-mix(in oklch, oklch(0.8 0.16 58.315) 85%, white);
-  --ui-warning-contrast: #18181b;
-  --ui-info: #3b82f6;
-  --ui-info-hover: #2563eb;
-  --ui-info-contrast: #ffffff;
-  --ui-surface: #1f1f23;
-  --ui-text: #fafafa;
-  --ui-text-muted: #a1a1aa;
-  --ui-border: #3f3f46;
-  --ui-overlay: rgb(0 0 0 / 0.6);
-  --ui-panel-shadow: 0 0 0 1px rgb(255 255 255 / 0.08), 0 8px 24px rgb(0 0 0 / 0.5);
-  --ui-border-strong: #52525b;
 }

--- a/packages/ui/src/composables/dom.ts
+++ b/packages/ui/src/composables/dom.ts
@@ -1,6 +1,16 @@
-import { isClient } from '@vueuse/core'
+import { shallowRef, toValue, watch } from 'vue'
+import type { Ref, ShallowRef, MaybeRefOrGetter } from 'vue'
+import { isClient, tryOnMounted } from '@vueuse/core'
 
 export type DOMTarget = HTMLElement | string | null
+
+/**
+ * What a DOM-element option should accept instead of a plain `Ref<T>` — every consumer here only
+ * ever reads `.value`, and the overwhelmingly common caller is `useTemplateRef()`, which returns
+ * `Readonly<ShallowRef<T>>`, not a full writable `Ref<T>`. A plain `Ref<T>` parameter type rejects
+ * that at the type level even though it works fine at runtime.
+ */
+export type ElRef<T> = Ref<T> | Readonly<ShallowRef<T>>
 
 export function resolveDOMTarget(target: undefined): undefined
 export function resolveDOMTarget(target: DOMTarget): HTMLElement | null
@@ -20,9 +30,6 @@ export function resolveDOMTarget(target: DOMTarget | undefined): HTMLElement | n
   }
   return target
 }
-
-import { shallowRef, toValue, watch, type ShallowRef, type MaybeRefOrGetter } from 'vue'
-import { tryOnMounted } from '@vueuse/core'
 
 export interface UseDOMTargetReturn {
   /** The resolved element, or `null` while unresolved. */

--- a/packages/ui/src/composables/useCollapse.ts
+++ b/packages/ui/src/composables/useCollapse.ts
@@ -1,12 +1,13 @@
 import { onScopeDispose, shallowRef, watch } from 'vue'
 import type { Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import type { ElRef } from './dom'
 
 export type CollapseState = 'open' | 'closed' | 'opening' | 'closing'
 
 export interface UseCollapseOptions {
   /** The element whose block-size is measured and animated. */
-  el: Ref<HTMLElement | null>
+  el: ElRef<HTMLElement | null>
   /** `false` skips the animated run() path — open/closed still snap to their resting styles instantly, just with no transition. A consumer driving their own exit animation reads `state`/`el` and overrides these resting styles from there. */
   motionCss?: () => boolean
 }

--- a/packages/ui/src/composables/useDial.ts
+++ b/packages/ui/src/composables/useDial.ts
@@ -2,6 +2,7 @@ import { computed, shallowRef, toValue } from 'vue'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { ssrWindow } from '../ssr'
+import type { ElRef } from './dom'
 
 /** 15deg-per-step mirrors mechanical mouse wheel detent; consumer-overridable. */
 export const DIAL_DEFAULT_DEGREES_PER_STEP = 15
@@ -9,7 +10,7 @@ export const DIAL_DEFAULT_DEGREES_PER_STEP = 15
 export interface UseDialOptions {
   /** The dial element — pointer angle is measured relative to its own
    * `getBoundingClientRect()` center, same as useKnob. */
-  dialEl: Ref<HTMLElement | null>
+  dialEl: ElRef<HTMLElement | null>
   /** Omit for a genuinely unbounded value (keeps counting forever in either direction). Bounding is independent per side — set only one to clamp just that end. */
   min?: MaybeRefOrGetter<number | undefined>
   max?: MaybeRefOrGetter<number | undefined>

--- a/packages/ui/src/composables/useDialog.ts
+++ b/packages/ui/src/composables/useDialog.ts
@@ -4,7 +4,7 @@ import { useEventListener } from '@vueuse/core'
 import { useLayer } from './useLayerStack'
 import { useScrollLock } from './useScrollLock'
 import { useInert } from './useInert'
-import { useDOMTarget, type DOMTarget } from './dom'
+import { useDOMTarget, type DOMTarget, type ElRef } from './dom'
 
 export type DialogCloseReason = 'trigger' | 'escape' | 'outside' | 'programmatic'
 
@@ -15,13 +15,13 @@ export interface DialogOpenChangeDetails {
 }
 
 export interface UseDialogOptions {
-  panelEl: Ref<HTMLElement | null>
+  panelEl: ElRef<HTMLElement | null>
   /**
    * Outermost teleported node — the element the overlay and panel both live inside.
    * `useInert` spares this rather than `panelEl`, otherwise the overlay is a sibling
    * and goes inert, silently killing outside-click. Falls back to `panelEl`.
    */
-  wrapperEl?: Ref<HTMLElement | null>
+  wrapperEl?: ElRef<HTMLElement | null>
   /**
    * Scopes the dialog to one element: the overlay, scroll lock and modality apply
    * only inside it, and the rest of the page stays interactive.

--- a/packages/ui/src/composables/useDock.ts
+++ b/packages/ui/src/composables/useDock.ts
@@ -1,7 +1,8 @@
 import { onMounted, onScopeDispose, nextTick, toValue, watch } from 'vue'
-import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { useEventListener, useResizeObserver } from '@vueuse/core'
 import { ssrWindow } from '../ssr'
+import type { ElRef } from './dom'
 
 export type DockOrientation = 'horizontal' | 'vertical'
 
@@ -74,7 +75,7 @@ export function dockItemOffsets(
 }
 
 export function useDock(
-  rootEl: Ref<HTMLElement | null>,
+  rootEl: ElRef<HTMLElement | null>,
   itemCount: MaybeRefOrGetter<number>,
   options: UseDockOptions = {},
 ): UseDockReturn {

--- a/packages/ui/src/composables/useFileDrop.ts
+++ b/packages/ui/src/composables/useFileDrop.ts
@@ -1,6 +1,7 @@
 import { shallowRef, toValue } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import type { ElRef } from './dom'
 
 export interface UseFileDropOptions {
   /** Called with the dropped `File[]` — validation (accept/maxSize/maxFiles) is the caller's job. */
@@ -13,7 +14,7 @@ export interface UseFileDropReturn {
 }
 
 export function useFileDrop(
-  targetEl: Ref<HTMLElement | null>,
+  targetEl: ElRef<HTMLElement | null>,
   options: UseFileDropOptions,
 ): UseFileDropReturn {
   const isDragOver = shallowRef(false)

--- a/packages/ui/src/composables/useFloatingPosition.ts
+++ b/packages/ui/src/composables/useFloatingPosition.ts
@@ -1,13 +1,14 @@
 import { shallowRef, toValue, watch, onScopeDispose } from 'vue'
-import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+import type { ElRef } from './dom'
 import { autoUpdate, computePosition, flip, offset, shift, size } from '@floating-ui/dom'
 import type { Placement, Side } from '@floating-ui/dom'
 
 export type Align = 'start' | 'center' | 'end'
 
 export interface UseFloatingPositionOptions {
-  referenceEl: Ref<HTMLElement | null>
-  floatingEl: Ref<HTMLElement | null>
+  referenceEl: ElRef<HTMLElement | null>
+  floatingEl: ElRef<HTMLElement | null>
   /** Positioning (and its scroll/resize tracking) only runs while true. */
   active: MaybeRefOrGetter<boolean>
   side?: MaybeRefOrGetter<Side>

--- a/packages/ui/src/composables/useKnob.ts
+++ b/packages/ui/src/composables/useKnob.ts
@@ -2,6 +2,7 @@ import { computed, shallowRef, toValue } from 'vue'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { ssrWindow } from '../ssr'
+import type { ElRef } from './dom'
 
 /** 270° sweep (−135° to +135°): standard rotary UI; gap at bottom for ambiguity. */
 export const KNOB_SWEEP_START_DEG = -135
@@ -10,7 +11,7 @@ export const KNOB_SWEEP_END_DEG = KNOB_SWEEP_START_DEG + KNOB_SWEEP_DEG
 
 export interface UseKnobOptions {
   /** The dial element — pointer angle is measured relative to its own `getBoundingClientRect()` center, per apple-design's direct-manipulation rule (angle-relative-to-center, not a raw x/y delta). */
-  dialEl: Ref<HTMLElement | null>
+  dialEl: ElRef<HTMLElement | null>
   min?: MaybeRefOrGetter<number>
   max?: MaybeRefOrGetter<number>
   step?: MaybeRefOrGetter<number>

--- a/packages/ui/src/composables/useMenu.ts
+++ b/packages/ui/src/composables/useMenu.ts
@@ -1,9 +1,9 @@
 import { onScopeDispose } from 'vue'
-import type { Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import type { ElRef } from './dom'
 
 export interface UseMenuOptions {
-  listEl: Ref<HTMLElement | null>
+  listEl: ElRef<HTMLElement | null>
   /** Fires when an enabled menuitem is activated — click, or Enter/Space while it has focus — and it isn't a submenu trigger (`aria-haspopup="menu"`; those route to `onExpand` instead). Firing means "activated," nothing more: the close-vs-keep decision is the caller's, since only it knows whether the item is a one-shot action or a toggle. `Menu.vue` closes unless the element carries `data-keep-open`; a bare useMenu consumer applies whatever policy it wants. */
   onSelect?: (itemEl: HTMLElement) => void
   /** Fires instead of `onSelect` when the activated item carries `aria-haspopup="menu"` — click, Enter/Space, or ArrowRight all converge here through the same real-click dispatch as a normal activation. `Menu.vue` wires this to open that row's nested submenu. */

--- a/packages/ui/src/composables/usePopover.ts
+++ b/packages/ui/src/composables/usePopover.ts
@@ -5,6 +5,7 @@ import type { Side } from '@floating-ui/dom'
 import { useLayer } from './useLayerStack'
 import { useFloatingPosition } from './useFloatingPosition'
 import type { Align } from './useFloatingPosition'
+import type { ElRef } from './dom'
 
 export type PopoverCloseReason = 'trigger' | 'escape' | 'outside' | 'programmatic'
 
@@ -15,8 +16,8 @@ export interface PopoverOpenChangeDetails {
 }
 
 export interface UsePopoverOptions {
-  triggerEl: Ref<HTMLElement | null>
-  positionerEl: Ref<HTMLElement | null>
+  triggerEl: ElRef<HTMLElement | null>
+  positionerEl: ElRef<HTMLElement | null>
   side?: MaybeRefOrGetter<Side>
   align?: MaybeRefOrGetter<Align>
   sideOffset?: MaybeRefOrGetter<number>
@@ -31,7 +32,7 @@ export interface UsePopoverOptions {
   /** Getter so the underlying prop stays reactive without being invoked by `toValue`. */
   beforeClose?: () => ((done: () => void) => void) | undefined
   /** Region this popover is scoped to, for Escape-key layer ownership. Omit for page-level. */
-  scope?: Ref<HTMLElement | null>
+  scope?: ElRef<HTMLElement | null>
 }
 
 export function usePopover(open: Ref<boolean>, options: UsePopoverOptions) {

--- a/packages/ui/src/composables/usePullToRefresh.ts
+++ b/packages/ui/src/composables/usePullToRefresh.ts
@@ -1,12 +1,13 @@
-import { computed, onScopeDispose, shallowRef, toValue } from 'vue'
+import { computed, onScopeDispose, shallowRef, toValue, watch } from 'vue'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import type { ElRef } from './dom'
 
 export type PullToRefreshState = 'idle' | 'pulling' | 'ready' | 'loading' | 'done'
 
 export interface UsePullToRefreshOptions {
   /** The scrollable element the gesture engages on — only when its `scrollTop` is 0 and the drag moves down. */
-  scrollEl: Ref<HTMLElement | null>
+  scrollEl: ElRef<HTMLElement | null>
   onRefresh: () => Promise<void> | void
   /** Px the zone can be dragged to before rubber-band resistance takes over. Default 80. */
   maxPull?: MaybeRefOrGetter<number | undefined>
@@ -164,9 +165,31 @@ export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRef
   useEventListener(options.scrollEl, 'pointerup', onPointerUp)
   useEventListener(options.scrollEl, 'pointercancel', onPointerCancel)
 
+  // A gesture's touch-action is decided by the browser before any JS runs on its first move —
+  // setting `touch-action: none` from a pointerdown handler is always one event too late. Instead,
+  // keep it settled ahead of time from scroll position alone: blocking only the native downward
+  // pan at scrollTop 0 leaves our own pointermove free to claim that exact drag, while every other
+  // direction (and all scrolling once away from the top) stays untouched.
+  let lastEl: HTMLElement | null = null
+  function updateTouchAction() {
+    const el = options.scrollEl.value
+    if (el) el.style.touchAction = el.scrollTop === 0 ? 'pan-x pan-up' : ''
+  }
+  useEventListener(options.scrollEl, 'scroll', updateTouchAction, { passive: true })
+  watch(
+    options.scrollEl,
+    (el) => {
+      if (lastEl && lastEl !== el) lastEl.style.touchAction = ''
+      lastEl = el
+      updateTouchAction()
+    },
+    { immediate: true },
+  )
+
   onScopeDispose(() => {
     refreshToken = null
     clearTimeout(doneTimer)
+    if (lastEl) lastEl.style.touchAction = ''
   })
 
   return { state, pullDistance, progress, refresh }

--- a/packages/ui/src/composables/useSheetDrag.ts
+++ b/packages/ui/src/composables/useSheetDrag.ts
@@ -1,6 +1,7 @@
 import { onScopeDispose, shallowRef, toValue, watch } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import type { ElRef } from './dom'
 
 export interface SheetSnapPoint {
   id: string
@@ -10,11 +11,11 @@ export interface SheetSnapPoint {
 
 export interface UseSheetDragOptions {
   /** The element that's translated (drag, snap-settle, entrance/exit) — never resized. */
-  panelEl: Ref<HTMLElement | null>
+  panelEl: ElRef<HTMLElement | null>
   /** Pointer-down here always starts a drag. */
-  handleEl: Ref<HTMLElement | null>
+  handleEl: ElRef<HTMLElement | null>
   /** Pointer-down here only starts a drag once its own scroll is at the top and the drag moves downward — otherwise it's an ordinary scroll. */
-  contentEl?: Ref<HTMLElement | null>
+  contentEl?: ElRef<HTMLElement | null>
   /** Ordered smallest to largest. */
   snapPoints: MaybeRefOrGetter<SheetSnapPoint[]>
   initialSnap?: MaybeRefOrGetter<string | undefined>

--- a/packages/ui/src/composables/useSlider.ts
+++ b/packages/ui/src/composables/useSlider.ts
@@ -2,14 +2,15 @@ import { computed, shallowRef, toValue } from 'vue'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import { ssrWindow } from '../ssr'
+import type { ElRef } from './dom'
 
 export type SliderOrientation = 'horizontal' | 'vertical'
 
 export interface UseSliderOptions {
   /** The track element — pointer coordinates are mapped against its rect. */
-  trackEl: Ref<HTMLElement | null>
+  trackEl: ElRef<HTMLElement | null>
   /** Thumb elements in index order — a track click focuses the one it moves. */
-  thumbEls?: Ref<HTMLElement[] | null>
+  thumbEls?: ElRef<HTMLElement[] | null>
   min?: MaybeRefOrGetter<number>
   max?: MaybeRefOrGetter<number>
   step?: MaybeRefOrGetter<number>

--- a/packages/ui/src/composables/useTabIndicator.ts
+++ b/packages/ui/src/composables/useTabIndicator.ts
@@ -1,8 +1,9 @@
 import { nextTick, onBeforeUnmount, shallowRef, toValue, watch } from 'vue'
-import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { MaybeRefOrGetter, Ref, WatchSource } from 'vue'
+import type { ElRef } from './dom'
 
 export interface UseTabIndicatorOptions {
-  listEl: Ref<HTMLElement | null>
+  listEl: ElRef<HTMLElement | null>
   /** Must match the `Tabs` instance's own `orientation` — same axis, same keys. */
   orientation?: MaybeRefOrGetter<'horizontal' | 'vertical'>
   /** The active element to measure inside `listEl`. Defaults to Tabs' own shape; SelectButton passes `'[data-checked]'` to reuse the same sliding technique for its single-select indicator. */
@@ -17,7 +18,7 @@ export interface UseTabIndicatorReturn {
 }
 
 export function useTabIndicator(
-  active: Ref<unknown>,
+  active: WatchSource<unknown>,
   options: UseTabIndicatorOptions,
 ): UseTabIndicatorReturn {
   const style = shallowRef<Record<string, string | undefined>>({})

--- a/packages/ui/src/composables/useTabs.ts
+++ b/packages/ui/src/composables/useTabs.ts
@@ -1,10 +1,11 @@
 import { nextTick, shallowRef, toValue } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
+import type { ElRef } from './dom'
 
 export interface UseTabsOptions<T> {
   items: MaybeRefOrGetter<readonly T[]>
-  listEl: Ref<HTMLElement | null>
+  listEl: ElRef<HTMLElement | null>
   /** Horizontal tabs use ←/→, vertical use ↑/↓ (per the APG tabs pattern). */
   orientation?: MaybeRefOrGetter<'horizontal' | 'vertical'>
   /** `automatic` (default): arrow keys select as they move focus. `manual`: arrow keys only move focus; Enter/Space on the focused tab selects it. Use this when switching tabs is expensive (e.g. loads data). */

--- a/packages/ui/src/composables/useToolbar.ts
+++ b/packages/ui/src/composables/useToolbar.ts
@@ -1,5 +1,6 @@
 import { computed, onMounted, onScopeDispose, shallowRef, toValue } from 'vue'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
+import type { ElRef } from './dom'
 
 export interface UseToolbarOptions {
   /** Horizontal toolbars use ←/→, vertical use ↑/↓ (per the APG toolbar pattern). */
@@ -30,7 +31,7 @@ const OVERFLOW_ITEM_SELECTOR = '[data-toolbar-overflow]'
 const ELLIPSIS_SELECTOR = '[data-toolbar-ellipsis]'
 
 export function useToolbar(
-  listEl: Ref<HTMLElement | null>,
+  listEl: ElRef<HTMLElement | null>,
   options: UseToolbarOptions = {},
 ): UseToolbarReturn {
   let current: HTMLElement | null = null

--- a/packages/ui/src/composables/useTooltip.ts
+++ b/packages/ui/src/composables/useTooltip.ts
@@ -4,6 +4,7 @@ import { useEventListener } from '@vueuse/core'
 import type { Side } from '@floating-ui/dom'
 import { useFloatingPosition } from './useFloatingPosition'
 import type { Align } from './useFloatingPosition'
+import type { ElRef } from './dom'
 
 export type TooltipCloseReason = 'pointer' | 'focus' | 'trigger' | 'escape' | 'programmatic'
 
@@ -47,8 +48,8 @@ export function __resetTooltipWarmth() {
 }
 
 export interface UseTooltipOptions {
-  triggerEl: Ref<HTMLElement | null>
-  positionerEl: Ref<HTMLElement | null>
+  triggerEl: ElRef<HTMLElement | null>
+  positionerEl: ElRef<HTMLElement | null>
   side?: MaybeRefOrGetter<Side>
   align?: MaybeRefOrGetter<Align>
   sideOffset?: MaybeRefOrGetter<number>

--- a/packages/ui/src/composables/useVirtualizer.ts
+++ b/packages/ui/src/composables/useVirtualizer.ts
@@ -1,13 +1,14 @@
 import { computed, onMounted, onScopeDispose, shallowRef, toValue, watch } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { useElementSize } from '@vueuse/core'
+import type { ElRef } from './dom'
 
 export type ScrollAlign = 'nearest' | 'start' | 'end' | 'center'
 
 export interface UseVirtualizerOptions {
   /** The scrollable box — for Select/Combobox this is the panel body that
    * already receives `maxHeight` from usePopover. */
-  containerEl: Ref<HTMLElement | null>
+  containerEl: ElRef<HTMLElement | null>
   count: MaybeRefOrGetter<number>
   /** Row size in px. Omit to auto-measure: the first rendered row's real
    * size is read once after it exists; a 36px estimate is used until then.

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -9,7 +9,16 @@ export interface UiTheme {
   /** Overrides the single `--ui-radius` token every component size derives from. */
   radius?: string
   /** App-wide default `ui` part-class/style overrides — same shape as each component's own `ui` prop. */
-  button?: { ui?: Partial<{ root: UiPartValue; badge: UiPartValue }> }
+  button?: {
+    ui?: Partial<{
+      root: UiPartValue
+      leading: UiPartValue
+      trailing: UiPartValue
+      content: UiPartValue
+      label: UiPartValue
+      badge: UiPartValue
+    }>
+  }
   buttonGroup?: { ui?: Partial<{ root: UiPartValue }> }
   splitButton?: {
     ui?: Partial<{
@@ -25,7 +34,7 @@ export interface UiTheme {
   loader?: { ui?: Partial<{ root: UiPartValue }> }
   skeleton?: { ui?: Partial<{ root: UiPartValue }> }
   badge?: { ui?: Partial<{ root: UiPartValue }> }
-  tag?: { ui?: Partial<{ root: UiPartValue; icon: UiPartValue }> }
+  tag?: { ui?: Partial<{ root: UiPartValue; icon: UiPartValue; label: UiPartValue }> }
   kbd?: { ui?: Partial<{ root: UiPartValue }> }
   avatar?: {
     ui?: Partial<{
@@ -55,6 +64,8 @@ export interface UiTheme {
       description: UiPartValue
       body: UiPartValue
       footer: UiPartValue
+      maximize: UiPartValue
+      close: UiPartValue
     }>
   }
   separator?: { ui?: Partial<{ root: UiPartValue; line: UiPartValue; text: UiPartValue }> }
@@ -66,6 +77,7 @@ export interface UiTheme {
       content: UiPartValue
       title: UiPartValue
       description: UiPartValue
+      actions: UiPartValue
       close: UiPartValue
     }>
   }
@@ -158,7 +170,9 @@ export interface UiTheme {
       body: UiPartValue
     }>
   }
-  collapsible?: { ui?: Partial<{ root: UiPartValue; trigger: UiPartValue; panel: UiPartValue }> }
+  collapsible?: {
+    ui?: Partial<{ root: UiPartValue; trigger: UiPartValue; panel: UiPartValue; body: UiPartValue }>
+  }
   bottomSheet?: {
     ui?: Partial<{
       panel: UiPartValue

--- a/packages/vapor-ui/package.json
+++ b/packages/vapor-ui/package.json
@@ -13,7 +13,7 @@
     "@floating-ui/dom": "^1.8.0",
     "@vueuse/core": "^14.4.0",
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.6"
+    "vue": "3.6.0-rc.7"
   },
   "devDependencies": {
     "@tsdown/css": "^0.22.14",

--- a/playground/nuxt/package.json
+++ b/playground/nuxt/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.6"
+    "vue": "3.6.0-rc.7"
   },
   "devDependencies": {
     "nuxt": "^4.5.2"

--- a/playground/vapor-interop/package.json
+++ b/playground/vapor-interop/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.6"
+    "vue": "3.6.0-rc.7"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.8",

--- a/playground/vapor/package.json
+++ b/playground/vapor/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.6"
+    "vue": "3.6.0-rc.7"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.8",

--- a/playground/vdom/package.json
+++ b/playground/vdom/package.json
@@ -13,7 +13,7 @@
     "gsap": "^3.15.0",
     "motion-v": "^2.4.0",
     "vael-ui": "workspace:*",
-    "vue": "3.6.0-rc.6",
+    "vue": "3.6.0-rc.7",
     "vue-i18n": "^11.4.8",
     "vue-router": "^5.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   brace-expansion: '>=5.0.8'
-  vue: 3.6.0-rc.4
+  vue: 3.6.0-rc.7
 
 importers:
 
@@ -56,19 +56,19 @@ importers:
         version: 5.3.0
       '@phosphor-icons/vue':
         specifier: ^2.2.1
-        version: 2.2.1(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 2.2.1(vue@3.6.0-rc.7(typescript@6.0.3))
       '@unhead/vue':
         specifier: ^2.1.17
-        version: 2.1.17(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 2.1.17(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vueuse/core':
         specifier: ^14.4.0
-        version: 14.4.0(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
       motion-v:
         specifier: ^2.4.0
-        version: 2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.4(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.7(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.7(typescript@6.0.3))
       shiki:
         specifier: ^4.4.3
         version: 4.4.3
@@ -77,23 +77,23 @@ importers:
         version: link:../packages/ui
       vee-validate:
         specifier: ^4.15.1
-        version: 4.15.1(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 4.15.1(vue@3.6.0-rc.7(typescript@6.0.3))
       vite-ssg:
         specifier: ^28.3.0
-        version: 28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3)))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)))(vue@3.6.0-rc.7(typescript@6.0.3))
       vue:
-        specifier: 3.6.0-rc.4
-        version: 3.6.0-rc.4(typescript@6.0.3)
+        specifier: 3.6.0-rc.7
+        version: 3.6.0-rc.7(typescript@6.0.3)
       vue-i18n:
         specifier: ^11.4.8
-        version: 11.4.8(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 11.4.8(vue@3.6.0-rc.7(typescript@6.0.3))
       vue-router:
         specifier: ^5.3.0
-        version: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       beasties:
         specifier: ^0.4.3
         version: 0.4.3
@@ -120,7 +120,7 @@ importers:
         version: 1.8.0
       '@vueuse/core':
         specifier: ^14.4.0
-        version: 14.4.0(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))
     devDependencies:
       '@nuxt/kit':
         specifier: ^4.5.2
@@ -130,13 +130,13 @@ importers:
         version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(yaml@2.9.0)
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vitest@4.1.10)
       motion-v:
         specifier: ^2.4.0
-        version: 2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.4(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.7(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.7(typescript@6.0.3))
       playwright:
         specifier: ^1.62.1
         version: 1.62.1
@@ -148,7 +148,7 @@ importers:
         version: 6.0.3
       unplugin-vue:
         specifier: ^7.2.0
-        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.4)(rollup@4.62.4)(terser@5.50.0)(vue@3.6.0-rc.4(typescript@6.0.3))(yaml@2.9.0)
+        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.4)(rollup@4.62.4)(terser@5.50.0)(vue@3.6.0-rc.7(typescript@6.0.3))(yaml@2.9.0)
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
@@ -157,10 +157,10 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0(supports-color@10.2.2))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       vitest-browser-vue:
         specifier: ^2.1.0
-        version: 2.1.0(@vue/compiler-dom@3.6.0-rc.4)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 2.1.0(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.7(typescript@6.0.3))
       vue:
-        specifier: 3.6.0-rc.4
-        version: 3.6.0-rc.4(typescript@6.0.3)
+        specifier: 3.6.0-rc.7
+        version: 3.6.0-rc.7(typescript@6.0.3)
       vue-component-type-helpers:
         specifier: ^3.3.10
         version: 3.3.10
@@ -175,20 +175,20 @@ importers:
         version: 1.8.0
       '@vueuse/core':
         specifier: ^14.4.0
-        version: 14.4.0(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))
       vael-ui:
         specifier: workspace:*
         version: link:../ui
       vue:
-        specifier: 3.6.0-rc.4
-        version: 3.6.0-rc.4(typescript@6.0.3)
+        specifier: 3.6.0-rc.7
+        version: 3.6.0-rc.7(typescript@6.0.3)
     devDependencies:
       '@tsdown/css':
         specifier: ^0.22.14
         version: 0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(yaml@2.9.0)
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vitest@4.1.10)
@@ -203,7 +203,7 @@ importers:
         version: 6.0.3
       unplugin-vue:
         specifier: ^7.2.0
-        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.4)(rollup@4.62.4)(terser@5.50.0)(vue@3.6.0-rc.4(typescript@6.0.3))(yaml@2.9.0)
+        version: 7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.4)(rollup@4.62.4)(terser@5.50.0)(vue@3.6.0-rc.7(typescript@6.0.3))(yaml@2.9.0)
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
@@ -220,8 +220,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.4
-        version: 3.6.0-rc.4(typescript@6.0.3)
+        specifier: 3.6.0-rc.7
+        version: 3.6.0-rc.7(typescript@6.0.3)
     devDependencies:
       nuxt:
         specifier: ^4.5.2
@@ -233,12 +233,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.4
-        version: 3.6.0-rc.4(typescript@6.0.3)
+        specifier: 3.6.0-rc.7
+        version: 3.6.0-rc.7(typescript@6.0.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -255,12 +255,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.4
-        version: 3.6.0-rc.4(typescript@6.0.3)
+        specifier: 3.6.0-rc.7
+        version: 3.6.0-rc.7(typescript@6.0.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vitest@4.1.10)
@@ -284,35 +284,35 @@ importers:
     dependencies:
       '@phosphor-icons/vue':
         specifier: ^2.2.1
-        version: 2.2.1(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 2.2.1(vue@3.6.0-rc.7(typescript@6.0.3))
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
       motion-v:
         specifier: ^2.4.0
-        version: 2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.4(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.7(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.7(typescript@6.0.3))
       vael-ui:
         specifier: workspace:*
         version: link:../../packages/ui
       vue:
-        specifier: 3.6.0-rc.4
-        version: 3.6.0-rc.4(typescript@6.0.3)
+        specifier: 3.6.0-rc.7
+        version: 3.6.0-rc.7(typescript@6.0.3)
       vue-i18n:
         specifier: ^11.4.8
-        version: 11.4.8(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 11.4.8(vue@3.6.0-rc.7(typescript@6.0.3))
       vue-router:
         specifier: ^5.3.0
-        version: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vee-validate:
         specifier: ^4.15.1
-        version: 4.15.1(vue@3.6.0-rc.4(typescript@6.0.3))
+        version: 4.15.1(vue@3.6.0-rc.7(typescript@6.0.3))
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
@@ -1099,7 +1099,7 @@ packages:
       nuxt: 4.5.2
       rolldown: ^1.0.0
       rollup-plugin-visualizer: ^6.0.0 || ^7.0.1
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
     peerDependenciesMeta:
       '@babel/plugin-proposal-decorators':
         optional: true
@@ -1370,7 +1370,7 @@ packages:
     resolution: {integrity: sha512-3RNg1utc2Z5RwPKWFkW3eXI/0BfQAwXgtFxPUPeSzi55jGYUq16b+UqcgbKLazWFlwg5R92OCLKjDiJjeiJcnA==}
     engines: {node: '>=14'}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1914,13 +1914,13 @@ packages:
   '@unhead/vue@2.1.17':
     resolution: {integrity: sha512-pnC8x9HLV3qQXdvWfylUEU25uhfCAy3ly9nmpQz84j9py818DRfU8jOsQ5wjdWtxyU1vX/fW2udfm4jtxUK8Bg==}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   '@unhead/vue@3.3.2':
     resolution: {integrity: sha512-WMmKtBxEzYrs2GBG3nuFFguuq8CdbQ6s7NX8TxBNev++WGh8otHa6KvmlMwNCawu+iH83aRWuCaxLpCKAuCDkQ==}
     peerDependencies:
       vite: '>=6.4.2'
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
       webpack: '>=5.0.0'
     peerDependenciesMeta:
       vite:
@@ -1938,14 +1938,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   '@vitejs/plugin-vue@6.0.8':
     resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   '@vitest/browser-playwright@4.1.10':
     resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
@@ -2000,7 +2000,7 @@ packages:
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
     peerDependenciesMeta:
       vue:
         optional: true
@@ -2027,8 +2027,8 @@ packages:
   '@vue/compiler-core@3.5.41':
     resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
 
-  '@vue/compiler-core@3.6.0-rc.4':
-    resolution: {integrity: sha512-9JRzXnjyCdo92wF0+bz8ab6HmP6Bp7KCkEeyCnfo3UBjDs+Q0/AB95K7cPCRCPDaj5X0w1sIkDVmd5uumQKBMA==}
+  '@vue/compiler-core@3.6.0-rc.7':
+    resolution: {integrity: sha512-8WWomL1m/mLayJEeTgAJdAYm+f7FIiPbFmHqHdSSFFIgBrNvyMwGsXcCP3fgJjiJ3E+/kcpFYvdyV/iY2i+eEQ==}
 
   '@vue/compiler-dom@3.5.40':
     resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
@@ -2036,14 +2036,14 @@ packages:
   '@vue/compiler-dom@3.5.41':
     resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
 
-  '@vue/compiler-dom@3.6.0-rc.4':
-    resolution: {integrity: sha512-adFundYV4A3X+uJ8/MMpRGFQZyeOZ4RESW5veyG7fxCaprDEYxIo43Ix75fYTQ+3HNz+UeOf22stCjSJVePuiQ==}
+  '@vue/compiler-dom@3.6.0-rc.7':
+    resolution: {integrity: sha512-ACdPq6xoMxraG0aMJUqo1ZeLTgZoatLOHvTbvqlsDywhcPueq8WyWONftAl6SzU9ooE/fYJbNUSRYEms22xHWQ==}
 
   '@vue/compiler-sfc@3.5.41':
     resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
 
-  '@vue/compiler-sfc@3.6.0-rc.4':
-    resolution: {integrity: sha512-1JuqndNMT9dzTTDcR4tP5Ul2EFDUoS+RXMQfq1RSp1TvjyH3F/8ptCjrZWFwF9nEtDzpaWsSuDqA6A1eFss/gA==}
+  '@vue/compiler-sfc@3.6.0-rc.7':
+    resolution: {integrity: sha512-MNxvA8ZlajbE+8+syBGXBRsFJIevyEEl085ibp3aqmr2FWJOetpW+aARlJpEJxkzUisz7aV7AJMJHnOL1Ccrhg==}
 
   '@vue/compiler-ssr@3.5.40':
     resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
@@ -2051,11 +2051,11 @@ packages:
   '@vue/compiler-ssr@3.5.41':
     resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
 
-  '@vue/compiler-ssr@3.6.0-rc.4':
-    resolution: {integrity: sha512-wLWUIrvtyABXCdrf8Rkz3YbEgLwfCtkpCLDfi9dnaHdEBRNAy2h+xamGGAxlO2NARI9Ophu6eoYtNS0L+uGb3A==}
+  '@vue/compiler-ssr@3.6.0-rc.7':
+    resolution: {integrity: sha512-M+gevHy3u+/Bt9id2ebvILwZKmFOvk+nfRPdG60xxDfICJlUC1fKWEsiPldz9QngjjOtaI1CP2/0DGhMCueH1Q==}
 
-  '@vue/compiler-vapor@3.6.0-rc.4':
-    resolution: {integrity: sha512-fTDZ4LyJXKmas4J8+BFs8Yj2DwYB+GHuB5/afcLuxx+/VVdEH+dq+ZHuGog25S71S5W76J17kV1X/Uyq+cvNOA==}
+  '@vue/compiler-vapor@3.6.0-rc.7':
+    resolution: {integrity: sha512-bV3LDpqsHESj8KO3ncJZPLzIatGcpT+ws+teePV4HDIJ7FiAKALSxb6yUuOg/J0O+oD2BwiWfV/nSmOQ5jt/sQ==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -2069,7 +2069,7 @@ packages:
   '@vue/devtools-core@8.2.1':
     resolution: {integrity: sha512-s/VfAY9oDTb/kFEWmy461jaFde2MIV1RO/gi1vwM+PAZBZ/Pc2Ndu3BNBdZUze8QDUuyYvElbEEGA83syjJfzA==}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   '@vue/devtools-kit@7.7.10':
     resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
@@ -2092,31 +2092,31 @@ packages:
   '@vue/reactivity@3.5.41':
     resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
 
-  '@vue/reactivity@3.6.0-rc.4':
-    resolution: {integrity: sha512-dC7nmEfyNaTOK+EmMzPpLN8nSxm+/SWd8q6Uy33fUF6HODQxZ0nEwjlYDtEqGgGSkymbHVxwQGc80F1BuKT6tA==}
+  '@vue/reactivity@3.6.0-rc.7':
+    resolution: {integrity: sha512-SaFGEMt25HCbLPIJqciStDDwgesfZOzlRiZPI5V9Jlchuv0u+nbNE8ei/HV3pqrnXJUJFHt4JwkeXHsDs56VnA==}
 
   '@vue/runtime-core@3.5.40':
     resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
 
-  '@vue/runtime-core@3.6.0-rc.4':
-    resolution: {integrity: sha512-jBujm+S/tz5+lAGxl2JXdbLOMG3QM3c5rpr9dSjiQxsuZalucw459cA6LjE350wyDWzbGVrcK+JFI7zpbgcu3w==}
+  '@vue/runtime-core@3.6.0-rc.7':
+    resolution: {integrity: sha512-L5atC1fUiMu0oMcjvb1LHGSwF8j5o8GmINC4SsDO+W78ztsiBrwRfjsyShpubNDnit4aNm7hzTJKZ8WB51KITQ==}
 
   '@vue/runtime-dom@3.5.40':
     resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
 
-  '@vue/runtime-dom@3.6.0-rc.4':
-    resolution: {integrity: sha512-x/Ye/3qKX9uXxH47HLytaaaI60o7F9qhgX0ZIi3nHLeuj1yqFSSllyCwlBKZz738XgzBzzrHN0UaAYapOYXNrA==}
+  '@vue/runtime-dom@3.6.0-rc.7':
+    resolution: {integrity: sha512-TqpIk49kcrpVmV4kacijO8EtEblS908mLBksa0lQ2/D59mJbUcGuhqxqE/akI/q7eSTWFdal1jcmXrPF4iQYFA==}
 
-  '@vue/runtime-vapor@3.6.0-rc.4':
-    resolution: {integrity: sha512-OqyMZhn0SJmP/EAsXOxVJq1jgyXDMQouD8Q8l6HvI6xMfZ/i9IuQ0+5oKihqumUJyO0wTFzpNd0DasJz4cxSTA==}
+  '@vue/runtime-vapor@3.6.0-rc.7':
+    resolution: {integrity: sha512-ScYPHrTcTni72Ll7Y+KsqpnXkUP9pHhxvjmW14FSCR9hjtYRV8RLvCP4v8hlwejSieYs0CQcD7wHKMI8aQ18FQ==}
     peerDependencies:
-      '@vue/runtime-dom': 3.6.0-rc.4
+      '@vue/runtime-dom': 3.6.0-rc.7
 
   '@vue/server-renderer@3.5.40':
     resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
 
-  '@vue/server-renderer@3.6.0-rc.4':
-    resolution: {integrity: sha512-kfm+0i8DECIux76JUNhiD2LhINatEe05u6sxxBwKKeoOlc1OSgZxXsfIwriIwrg7i7ZLoYo/l5M8Wu4Rho9fHQ==}
+  '@vue/server-renderer@3.6.0-rc.7':
+    resolution: {integrity: sha512-0c7XLrVUuQhPA1DrB40y+DrjWIEnpIu6Eq9NeRmeFl3usdBoVwvY5NCTAIEOH/bQskjeDRU6svnQyKMWKs7M+g==}
 
   '@vue/shared@3.5.40':
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
@@ -2124,15 +2124,15 @@ packages:
   '@vue/shared@3.5.41':
     resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
 
-  '@vue/shared@3.6.0-rc.4':
-    resolution: {integrity: sha512-7l42Ia1Z5xYLh4zTgqKtZow58wf6kqVY90qnxtW35zxsCR+2iyz1tRAgQULSC5stD7j3s1YtywYhBAybaDYrQw==}
+  '@vue/shared@3.6.0-rc.7':
+    resolution: {integrity: sha512-KOGkvUjgtrBtG2YEr+eB3LfHSdljkPUvV51fpnh7VUiTtCo1gBkYykgtg6/mFwyA+BhCsTDwEP87T6zdjtmOug==}
 
   '@vue/test-utils@2.4.11':
     resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
     peerDependencies:
       '@vue/compiler-dom': 3.x
       '@vue/server-renderer': 3.x
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
     peerDependenciesMeta:
       '@vue/server-renderer':
         optional: true
@@ -2140,7 +2140,7 @@ packages:
   '@vueuse/core@14.4.0':
     resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   '@vueuse/metadata@14.4.0':
     resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
@@ -2148,7 +2148,7 @@ packages:
   '@vueuse/shared@14.4.0':
     resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   '@yuku-codegen/binding-android-arm64@0.8.7':
     resolution: {integrity: sha512-C/0zV5IhgVdYhGJTwrY0v8dknxlhiKwtVJkMUaexu9/QvRmzlV4vfU3hZlUSgqc2BxQHntL1mCVbDq8j0FRFDw==}
@@ -3828,7 +3828,7 @@ packages:
     resolution: {integrity: sha512-kRDGMAZk3nvdjEO36Wo6pezSEIStGXGhVFiwo1QkUDsUg8mB5igjYPXyece8wtu2DrHhmFfA6Y1nOz07+5QH4A==}
     peerDependencies:
       '@vueuse/core': '>=10.0.0'
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -5048,7 +5048,7 @@ packages:
     resolution: {integrity: sha512-6JHWcRbLO3bySOsipQSW9n2VRoPqsx9GLSWBfp7QLPCvpUr/edeAXR7pSl44EEJ+FIp9bG8Zm+xm5dnM/yir4Q==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -5181,7 +5181,7 @@ packages:
   vee-validate@4.15.1:
     resolution: {integrity: sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   verkit@0.3.2:
     resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
@@ -5253,7 +5253,7 @@ packages:
     resolution: {integrity: sha512-G2aQ676fLBPnYhRi5lsARoL4hbtc/sx6fVzO7p44AB+1xQXo2UuiRgv7K26UdijrNzmuQprmJ121n3rdjBk1CA==}
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   vite-ssg-sitemap@0.10.0:
     resolution: {integrity: sha512-OIja4fqUMcvWl5+bxQARe3LgzWTd8U/dWHWgrqiC7vv3AmTn0YnhMNUAimQ0M/0Aa9myEIAGLV0yKlYbKP8BJQ==}
@@ -5266,7 +5266,7 @@ packages:
       beasties: ^0.3.5
       prettier: ^3.3.0
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0-0 || ^8.0.0-0
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
       vue-router: ^4.0.1 || ^5.0.0-0
     peerDependenciesMeta:
       beasties:
@@ -5323,7 +5323,7 @@ packages:
     resolution: {integrity: sha512-K3H/oxIOY4EjXx2bxwrLsPg4jTMvzpRW6Jb6T8XZRoxUvmDVwGkd8mua130F8GZezE7H5QYoXd/S8hYijw7j5g==}
     peerDependencies:
       vitest: ^4.0.0-0
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   vitest@4.1.10:
     resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
@@ -5399,7 +5399,7 @@ packages:
     resolution: {integrity: sha512-0ULeHP6Z9CGvAm67S77ZEp41cfGXIREGL8qfhos2BMgcQQewtQcDKuojt6jjasAD/S8GwfTp2ySPmDSpwvrCMQ==}
     engines: {node: '>= 22'}
     peerDependencies:
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
 
   vue-router@5.2.0:
     resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
@@ -5408,7 +5408,7 @@ packages:
       '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
       pinia: ^3.0.4 || ^4.0.2
       vite: ^7.3.0 || ^8.0.0
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
     peerDependenciesMeta:
       '@pinia/colada':
         optional: true
@@ -5426,7 +5426,7 @@ packages:
       '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
       pinia: ^3.0.4 || ^4.0.2
       vite: ^7.3.0 || ^8.0.0
-      vue: 3.6.0-rc.4
+      vue: 3.6.0-rc.7
     peerDependenciesMeta:
       '@pinia/colada':
         optional: true
@@ -5443,8 +5443,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.6.0-rc.4:
-    resolution: {integrity: sha512-/jb/st6piGML3Y5cP57QD8fPqoSixUIZYLsUYzokCZgx90lIF3Sis3O8yu0emWoeyuwB8S3OcdTJozae1tsAZQ==}
+  vue@3.6.0-rc.7:
+    resolution: {integrity: sha512-QtoaLTwen3S853DMz9lRxUTorrb7mcbiZ4L7HzoVEqjjGVXeKsDoNZOzryFvErAwa8FHUu5jK5glK+KmY0Z8HQ==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -6470,12 +6470,12 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.0)(rolldown@1.2.4)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.0)(rolldown@1.2.4)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
-      '@vue/devtools-core': 8.2.1(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@vue/devtools-core': 8.2.1(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vue/devtools-kit': 8.2.1
       birpc: 4.1.0
       consola: 3.4.2
@@ -6503,7 +6503,7 @@ snapshots:
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.5.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+      vite-plugin-vue-tracer: 1.5.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       which: 6.0.1
       ws: 8.21.3
     transitivePeerDependencies:
@@ -6569,7 +6569,7 @@ snapshots:
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
-      '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vue/shared': 3.5.41
       consola: 3.4.2
       defu: 6.1.7
@@ -6593,7 +6593,7 @@ snapshots:
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.2.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
     optionalDependencies:
@@ -6669,11 +6669,11 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(cb7bf755437fe1f9e4de4282a12debef)':
+  '@nuxt/vite-builder@4.5.2(880d37d2ae0c51f384bbd7476e462c4b)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
-      '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       autoprefixer: 10.5.4(postcss@8.5.26)
       consola: 3.4.2
       cssnano: 8.0.5(postcss@8.5.26)
@@ -6700,7 +6700,7 @@ snapshots:
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
       vite-plugin-checker: 0.14.5(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(optionator@0.9.4)(oxlint@1.78.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
       vue-bundle-renderer: 2.3.2
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
@@ -6855,9 +6855,9 @@ snapshots:
       is-glob: 4.0.3
       picomatch: 4.0.5
 
-  '@phosphor-icons/vue@2.2.1(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@phosphor-icons/vue@2.2.1(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7286,19 +7286,19 @@ snapshots:
     dependencies:
       unhead: 2.1.17
 
-  '@unhead/vue@2.1.17(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@unhead/vue@2.1.17(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       hookable: 6.1.1
       unhead: 2.1.17
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
-  '@unhead/vue@3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@unhead/vue@3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@unhead/bundler': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(unhead@3.3.2(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       hookable: 6.1.1
       unhead: 3.3.2(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
     optionalDependencies:
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -7334,7 +7334,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@vitejs/plugin-vue-jsx@5.1.6(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
@@ -7342,15 +7342,15 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -7435,7 +7435,7 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/common@3.1.4(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@vue-macros/common@3.1.4(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.41
       ast-kit: 2.2.0
@@ -7443,7 +7443,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.2
     optionalDependencies:
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
@@ -7491,10 +7491,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-rc.4':
+  '@vue/compiler-core@3.6.0-rc.7':
     dependencies:
       '@babel/parser': 7.29.8
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/shared': 3.6.0-rc.7
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -7510,10 +7510,10 @@ snapshots:
       '@vue/compiler-core': 3.5.41
       '@vue/shared': 3.5.41
 
-  '@vue/compiler-dom@3.6.0-rc.4':
+  '@vue/compiler-dom@3.6.0-rc.7':
     dependencies:
-      '@vue/compiler-core': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/compiler-core': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
 
   '@vue/compiler-sfc@3.5.41':
     dependencies:
@@ -7527,14 +7527,14 @@ snapshots:
       postcss: 8.5.26
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-rc.4':
+  '@vue/compiler-sfc@3.6.0-rc.7':
     dependencies:
       '@babel/parser': 7.29.8
-      '@vue/compiler-core': 3.6.0-rc.4
-      '@vue/compiler-dom': 3.6.0-rc.4
-      '@vue/compiler-ssr': 3.6.0-rc.4
-      '@vue/compiler-vapor': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/compiler-core': 3.6.0-rc.7
+      '@vue/compiler-dom': 3.6.0-rc.7
+      '@vue/compiler-ssr': 3.6.0-rc.7
+      '@vue/compiler-vapor': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.26
@@ -7551,16 +7551,16 @@ snapshots:
       '@vue/compiler-dom': 3.5.41
       '@vue/shared': 3.5.41
 
-  '@vue/compiler-ssr@3.6.0-rc.4':
+  '@vue/compiler-ssr@3.6.0-rc.7':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/compiler-dom': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
 
-  '@vue/compiler-vapor@3.6.0-rc.4':
+  '@vue/compiler-vapor@3.6.0-rc.7':
     dependencies:
       '@babel/parser': 7.29.8
-      '@vue/compiler-dom': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/compiler-dom': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -7574,11 +7574,11 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.2.1
 
-  '@vue/devtools-core@8.2.1(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@vue/devtools-core@8.2.1(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@vue/devtools-kit': 8.2.1
       '@vue/devtools-shared': 8.2.1
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   '@vue/devtools-kit@7.7.10':
     dependencies:
@@ -7622,9 +7622,9 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.41
 
-  '@vue/reactivity@3.6.0-rc.4':
+  '@vue/reactivity@3.6.0-rc.7':
     dependencies:
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/shared': 3.6.0-rc.7
 
   '@vue/runtime-core@3.5.40':
     dependencies:
@@ -7632,10 +7632,10 @@ snapshots:
       '@vue/shared': 3.5.40
     optional: true
 
-  '@vue/runtime-core@3.6.0-rc.4':
+  '@vue/runtime-core@3.6.0-rc.7':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/reactivity': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
 
   '@vue/runtime-dom@3.5.40':
     dependencies:
@@ -7645,18 +7645,18 @@ snapshots:
       csstype: 3.2.3
     optional: true
 
-  '@vue/runtime-dom@3.6.0-rc.4':
+  '@vue/runtime-dom@3.6.0-rc.7':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.4
-      '@vue/runtime-core': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/reactivity': 3.6.0-rc.7
+      '@vue/runtime-core': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
       csstype: 3.2.3
 
-  '@vue/runtime-vapor@3.6.0-rc.4(@vue/runtime-dom@3.6.0-rc.4)':
+  '@vue/runtime-vapor@3.6.0-rc.7(@vue/runtime-dom@3.6.0-rc.7)':
     dependencies:
-      '@vue/reactivity': 3.6.0-rc.4
-      '@vue/runtime-dom': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/reactivity': 3.6.0-rc.7
+      '@vue/runtime-dom': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
 
   '@vue/server-renderer@3.5.40':
     dependencies:
@@ -7665,40 +7665,40 @@ snapshots:
       '@vue/shared': 3.5.40
     optional: true
 
-  '@vue/server-renderer@3.6.0-rc.4':
+  '@vue/server-renderer@3.6.0-rc.7':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-rc.4
-      '@vue/runtime-dom': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/compiler-ssr': 3.6.0-rc.7
+      '@vue/runtime-dom': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
 
   '@vue/shared@3.5.40':
     optional: true
 
   '@vue/shared@3.5.41': {}
 
-  '@vue/shared@3.6.0-rc.4': {}
+  '@vue/shared@3.6.0-rc.7': {}
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.4)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.4
+      '@vue/compiler-dom': 3.6.0-rc.7
       js-beautify: 1.15.4
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
       vue-component-type-helpers: 3.3.10
     optionalDependencies:
       '@vue/server-renderer': 3.5.40
 
-  '@vueuse/core@14.4.0(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@vueuse/core@14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.4.0
-      '@vueuse/shared': 14.4.0(vue@3.6.0-rc.4(typescript@6.0.3))
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      '@vueuse/shared': 14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   '@vueuse/metadata@14.4.0': {}
 
-  '@vueuse/shared@14.4.0(vue@3.6.0-rc.4(typescript@6.0.3))':
+  '@vueuse/shared@14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   '@yuku-codegen/binding-android-arm64@0.8.7':
     optional: true
@@ -9278,14 +9278,14 @@ snapshots:
 
   motion-utils@13.0.0: {}
 
-  motion-v@2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.4(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.4(typescript@6.0.3)):
+  motion-v@2.4.0(@vueuse/core@14.4.0(vue@3.6.0-rc.7(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
-      '@vueuse/core': 14.4.0(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@vueuse/core': 14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))
       framer-motion: 13.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       hey-listen: 1.0.8
       motion-dom: 13.0.0
       motion-utils: 13.0.0
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -9464,13 +9464,13 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.7(esbuild@0.28.2)(magicast@0.5.4)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(cac@6.7.14)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.0)(rolldown@1.2.4)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.0)(rolldown@1.2.4)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(2dbf0865b66491d905e98775edc2fe26)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(cb7bf755437fe1f9e4de4282a12debef)
-      '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@nuxt/vite-builder': 4.5.2(880d37d2ae0c51f384bbd7476e462c4b)
+      '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
       compatx: 0.2.0
@@ -9519,9 +9519,9 @@ snapshots:
       unrouting: 0.2.3
       untyped: 2.0.0
       verkit: 0.3.2
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
       vue-component-type-helpers: 3.3.9
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     optionalDependencies:
       '@types/node': 26.1.1
     transitivePeerDependencies:
@@ -10704,7 +10704,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin-vue@7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.4)(rollup@4.62.4)(terser@5.50.0)(vue@3.6.0-rc.4(typescript@6.0.3))(yaml@2.9.0):
+  unplugin-vue@7.2.0(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.4)(rollup@4.62.4)(terser@5.50.0)(vue@3.6.0-rc.7(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -10712,7 +10712,7 @@ snapshots:
       obug: 2.1.4
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -10804,11 +10804,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vee-validate@4.15.1(vue@3.6.0-rc.4(typescript@6.0.3)):
+  vee-validate@4.15.1(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 7.7.10
       type-fest: 4.41.0
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   verkit@0.3.2: {}
 
@@ -10885,7 +10885,7 @@ snapshots:
     optionalDependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
 
-  vite-plugin-vue-tracer@1.5.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3)):
+  vite-plugin-vue-tracer@1.5.0(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.1.1
@@ -10893,24 +10893,24 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
   vite-ssg-sitemap@0.10.0: {}
 
-  vite-ssg@28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3)))(vue@3.6.0-rc.4(typescript@6.0.3)):
+  vite-ssg@28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)))(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
       '@unhead/dom': 2.1.17(unhead@2.1.17)
-      '@unhead/vue': 2.1.17(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@unhead/vue': 2.1.17(vue@3.6.0-rc.7(typescript@6.0.3))
       ansis: 4.3.1
       cac: 6.7.14
       html-minifier-terser: 7.2.0
       html5parser: 2.0.2
       jsdom: 28.1.0(supports-color@10.2.2)
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
     optionalDependencies:
       beasties: 0.4.3
-      vue-router: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3))
+      vue-router: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     transitivePeerDependencies:
       - '@noble/hashes'
       - canvas
@@ -10932,11 +10932,11 @@ snapshots:
       terser: 5.50.0
       yaml: 2.9.0
 
-  vitest-browser-vue@2.1.0(@vue/compiler-dom@3.6.0-rc.4)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.4(typescript@6.0.3)):
+  vitest-browser-vue@2.1.0(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
-      '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.6.0-rc.4)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.7(typescript@6.0.3))
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0(supports-color@10.2.2))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - '@vue/server-renderer'
@@ -11002,18 +11002,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-i18n@11.4.8(vue@3.6.0-rc.4(typescript@6.0.3)):
+  vue-i18n@11.4.8(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
       '@intlify/core-base': 11.4.8
       '@intlify/devtools-types': 11.4.8
       '@intlify/shared': 11.4.8
       '@vue/devtools-api': 6.6.4
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
 
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.4(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@vue-macros/common': 3.1.4(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vue/devtools-api': 8.2.1
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
@@ -11029,7 +11029,7 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.41
@@ -11044,9 +11044,9 @@ snapshots:
       - unloader
       - webpack
 
-  vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.4(typescript@6.0.3)):
+  vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
-      '@vue-macros/common': 3.1.4(vue@3.6.0-rc.4(typescript@6.0.3))
+      '@vue-macros/common': 3.1.4(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vue/devtools-api': 8.2.1
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
@@ -11062,7 +11062,7 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      vue: 3.6.0-rc.4(typescript@6.0.3)
+      vue: 3.6.0-rc.7(typescript@6.0.3)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.41
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
@@ -11082,14 +11082,14 @@ snapshots:
       '@vue/language-core': 3.3.10
       typescript: 6.0.3
 
-  vue@3.6.0-rc.4(typescript@6.0.3):
+  vue@3.6.0-rc.7(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-rc.4
-      '@vue/compiler-sfc': 3.6.0-rc.4
-      '@vue/runtime-dom': 3.6.0-rc.4
-      '@vue/runtime-vapor': 3.6.0-rc.4(@vue/runtime-dom@3.6.0-rc.4)
-      '@vue/server-renderer': 3.6.0-rc.4
-      '@vue/shared': 3.6.0-rc.4
+      '@vue/compiler-dom': 3.6.0-rc.7
+      '@vue/compiler-sfc': 3.6.0-rc.7
+      '@vue/runtime-dom': 3.6.0-rc.7
+      '@vue/runtime-vapor': 3.6.0-rc.7(@vue/runtime-dom@3.6.0-rc.7)
+      '@vue/server-renderer': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,10 +355,6 @@ packages:
     resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0':
-    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
@@ -413,17 +409,9 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0':
-    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@8.0.4':
-    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
@@ -436,11 +424,6 @@ packages:
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@8.0.4':
-    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-syntax-jsx@7.29.7':
@@ -476,10 +459,6 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/types@8.0.4':
-    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
@@ -1789,9 +1768,6 @@ packages:
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
-
-  '@types/jsesc@2.5.1':
-    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -5383,9 +5359,6 @@ packages:
   vue-component-type-helpers@3.3.10:
     resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
 
-  vue-component-type-helpers@3.3.9:
-    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
-
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
@@ -5400,24 +5373,6 @@ packages:
     engines: {node: '>= 22'}
     peerDependencies:
       vue: 3.6.0-rc.7
-
-  vue-router@5.2.0:
-    resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
-    peerDependencies:
-      '@pinia/colada': '>=0.21.2'
-      '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
-      pinia: ^3.0.4 || ^4.0.2
-      vite: ^7.3.0 || ^8.0.0
-      vue: 3.6.0-rc.7
-    peerDependenciesMeta:
-      '@pinia/colada':
-        optional: true
-      '@vue/compiler-sfc':
-        optional: true
-      pinia:
-        optional: true
-      vite:
-        optional: true
 
   vue-router@5.3.0:
     resolution: {integrity: sha512-a2PBXX9yfkS58JzSJALUffgDa09lEzKmCcEnLaepoIr88L+9hEnsgEQkcadJGID+vtHa0gFpVo064zmylA9fcg==}
@@ -5640,15 +5595,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/generator@8.0.0':
-    dependencies:
-      '@babel/parser': 8.0.4
-      '@babel/types': 8.0.4
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
-      jsesc: 3.1.0
-
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.8
@@ -5723,11 +5669,7 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-identifier@8.0.4': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
@@ -5739,10 +5681,6 @@ snapshots:
   '@babel/parser@7.29.8':
     dependencies:
       '@babel/types': 7.29.8
-
-  '@babel/parser@8.0.4':
-    dependencies:
-      '@babel/types': 8.0.4
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
@@ -5789,11 +5727,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-
-  '@babel/types@8.0.4':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0
-      '@babel/helper-validator-identifier': 8.0.4
 
   '@blazediff/core@1.9.1': {}
 
@@ -7149,8 +7082,6 @@ snapshots:
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -9520,8 +9451,8 @@ snapshots:
       untyped: 2.0.0
       verkit: 0.3.2
       vue: 3.6.0-rc.7(typescript@6.0.3)
-      vue-component-type-helpers: 3.3.9
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
+      vue-component-type-helpers: 3.3.10
+      vue-router: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     optionalDependencies:
       '@types/node': 26.1.1
     transitivePeerDependencies:
@@ -10986,8 +10917,6 @@ snapshots:
 
   vue-component-type-helpers@3.3.10: {}
 
-  vue-component-type-helpers@3.3.9: {}
-
   vue-devtools-stub@0.1.0: {}
 
   vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
@@ -11009,40 +10938,6 @@ snapshots:
       '@intlify/shared': 11.4.8
       '@vue/devtools-api': 6.6.4
       vue: 3.6.0-rc.7(typescript@6.0.3)
-
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)):
-    dependencies:
-      '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.4(vue@3.6.0-rc.7(typescript@6.0.3))
-      '@vue/devtools-api': 8.2.1
-      ast-walker-scope: 0.9.0
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      nostics: 1.2.0
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
-      unplugin-utils: 0.3.2
-      vue: 3.6.0-rc.7(typescript@6.0.3)
-      yaml: 2.9.0
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.41
-      vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - webpack
 
   vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
@@ -11168,7 +11063,8 @@ snapshots:
 
   yallist@5.0.0: {}
 
-  yaml@2.9.0: {}
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@22.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,23 +7,23 @@ allowBuilds:
   sharp: true
 overrides:
   brace-expansion: '>=5.0.8'
-  vue: 3.6.0-rc.4
+  vue: 3.6.0-rc.7
 minimumReleaseAgeExclude:
   - '@vue/language-core@3.3.8 || 3.3.10'
   - vue-tsc@3.3.8 || 3.3.10
   - lint-staged@17.2.0
   - vue-component-type-helpers@3.3.8 || 3.3.10
-  - vue@3.6.0-rc.4
-  - '@vue/compiler-core@3.6.0-rc.4'
-  - '@vue/compiler-dom@3.6.0-rc.4'
-  - '@vue/compiler-sfc@3.6.0-rc.4'
-  - '@vue/compiler-ssr@3.6.0-rc.4'
-  - '@vue/compiler-vapor@3.6.0-rc.4'
-  - '@vue/reactivity@3.6.0-rc.4'
-  - '@vue/runtime-core@3.6.0-rc.4'
-  - '@vue/runtime-dom@3.6.0-rc.4'
-  - '@vue/runtime-vapor@3.6.0-rc.4'
-  - '@vue/server-renderer@3.6.0-rc.4'
-  - '@vue/shared@3.6.0-rc.4'
+  - vue@3.6.0-rc.7
+  - '@vue/compiler-core@3.6.0-rc.7'
+  - '@vue/compiler-dom@3.6.0-rc.7'
+  - '@vue/compiler-sfc@3.6.0-rc.7'
+  - '@vue/compiler-ssr@3.6.0-rc.7'
+  - '@vue/compiler-vapor@3.6.0-rc.7'
+  - '@vue/reactivity@3.6.0-rc.7'
+  - '@vue/runtime-core@3.6.0-rc.7'
+  - '@vue/runtime-dom@3.6.0-rc.7'
+  - '@vue/runtime-vapor@3.6.0-rc.7'
+  - '@vue/server-renderer@3.6.0-rc.7'
+  - '@vue/shared@3.6.0-rc.7'
   - vue-component-meta@3.3.10
   - motion-v@2.4.0


### PR DESCRIPTION
## 0.3.2 patch

Most of this came from building a real dashboard on 0.3.1 and logging every place the library fought back (`vael-ui-issues.md`). Also bumps Vue to 3.6.0-rc.7.

### Fixes

- **PullToRefresh** no longer forces `overflow-y: auto` onto its own root. It owns scrolling only when you don't pass a `scrollEl`. `touch-action` is set from scroll position up front instead of mid gesture.
- **Dialog** `maximizable` now works when a custom panel width is set.
- Consumer `class` now wins over a component's internal class (around 40 components), matching how the `ui` prop already behaved.
- Design tokens are genuinely inside `@layer ui-components`, so an unlayered `:root` override in your app wins.
- **Textarea** `#bottom-end` sits at the end when it's the only bottom slot.
- **Menu** forwards a custom `#item` slot into nested submenus.
- **Tour** spotlight no longer parks in the top-left corner during a step change, and the glide to the next target is quicker.

### New `ui` parts

Previously reachable only through `:deep()` and an internal class name:

- `Button`: `leading`, `trailing`, `content`, `label`
- `MenuList`: the `#item` slot gains an `isGroup` boolean
- `Tag`: `label`
- `Dialog`: `maximize`, `close`
- `Message`: `actions`
- `Collapsible`: `body`

### Checks

936 vael-ui tests, 19 vapor-ui tests, typecheck, build plus chunk-split verification. Changeset: patch, 0.3.1 to 0.3.2.
