### PR TITLE
fix(ui): 0.3.3 patch — touch-first pull-to-refresh, Vapor Menu submenus

### DIFF
--- a/.changeset/fix-0-3-3-ptr-menu-vapor.md
+++ b/.changeset/fix-0-3-3-ptr-menu-vapor.md
@@ -1,0 +1,29 @@
+---
+'vael-ui': patch
+---
+
+## Fixes
+
+- **`PullToRefresh`:** the pull gesture is driven by touch events again, not Pointer Events.
+  0.3.2 moved it to `pointermove` + a `touch-action` that got toggled from a `scroll` listener,
+  and neither reliably holds back the native scroll: `preventDefault()` on a `pointermove` does
+  nothing to scrolling, and re-arming `touch-action` always lagged the moment you settled back
+  at the top by an event or two. It now uses a non-passive `touchmove` + `preventDefault()` —
+  the one thing browsers actually honour — for exactly the span of a downward drag while the
+  scroll box is at `scrollTop === 0`, and mutates no styles on the consumer's element. Pointer
+  events stay wired up for a real mouse only. The gesture engages strictly at the top of the
+  container; anywhere else it's an ordinary scroll.
+
+- **`Menu`:** nested submenus render correctly in the Vapor build. The recursive `<Menu>` was
+  resolved by name (`resolveComponent('Menu', true)`), which returns the bare string — not the
+  component — inside a Vapor render, so every submenu came out as a stray `<menu>` element with
+  its props dropped and never opened. It's now an explicit self-import. A custom `#item` slot
+  also keeps applying at every submenu depth instead of reverting to the default row past level
+  one (and, under the Vapor compiler, instead of a `<slot>` forward that re-resolved against the
+  submenu and recursed).
+
+## Also
+
+- The whole Vue toolchain is pinned to one RC (`3.6.0-rc.7`) via `pnpm.overrides`, not just
+  `vue` itself — a second copy of `@vue/runtime-vapor` in the tree breaks recursive Vapor
+  components, since self-reference resolves against the wrong instance registry.

--- a/docs/src/demos/Menu/07-CustomRowsInSubmenus.vue
+++ b/docs/src/demos/Menu/07-CustomRowsInSubmenus.vue
@@ -1,0 +1,105 @@
+<template>
+  <section class="demo">
+    <h3>Custom rows through nested submenus</h3>
+    <p class="note">
+      The <code>#item</code> slot keeps rendering your own markup at every depth — a submenu row is
+      not a separate, un-styleable path. Here each row is a glyph, a label, and a hint line, three
+      levels deep.
+    </p>
+    <div class="row">
+      <Menu :items="items" @select="onSelect">
+        <template #trigger>
+          <Button variant="secondary">Insert</Button>
+        </template>
+        <template #item="{ item }">
+          <span class="cell">
+            <span class="cell-glyph" aria-hidden="true">{{ item.glyph ?? '•' }}</span>
+            <span class="cell-text">
+              <span class="cell-label">{{ item.label }}</span>
+              <span v-if="item.hint" class="cell-hint">{{ item.hint }}</span>
+            </span>
+          </span>
+        </template>
+      </Menu>
+      <output class="panel-text">{{
+        picked ? `Inserted: ${picked}` : 'Nothing inserted yet'
+      }}</output>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { shallowRef } from 'vue'
+import { Button, Menu } from 'vael-ui'
+import type { MenuEntry, MenuItemData } from 'vael-ui'
+
+interface Row extends MenuItemData {
+  glyph?: string
+  hint?: string
+  items?: Row[]
+}
+
+const picked = shallowRef('')
+function onSelect(item: MenuItemData) {
+  picked.value = (item as Row).label
+}
+
+const items: MenuEntry<Row>[] = [
+  { label: 'Text', value: 'text', glyph: 'T', hint: 'Plain paragraph' },
+  {
+    label: 'Media',
+    glyph: '▣',
+    items: [
+      { label: 'Image', value: 'image', glyph: '🖼', hint: 'Upload or paste a URL' },
+      { label: 'Video', value: 'video', glyph: '▶', hint: 'YouTube, Vimeo, or a file' },
+      {
+        label: 'Embed',
+        glyph: '⧉',
+        items: [
+          { label: 'Figma', value: 'figma', glyph: 'F', hint: 'Live design frame' },
+          { label: 'CodePen', value: 'codepen', glyph: '{ }', hint: 'Runnable snippet' },
+        ],
+      },
+    ],
+  },
+  { type: 'separator' },
+  { label: 'Divider', value: 'divider', glyph: '—', hint: 'Horizontal rule' },
+]
+</script>
+
+<style scoped>
+.row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.panel-text {
+  display: block;
+  margin-block-start: 1rem;
+  font-size: 0.875rem;
+  color: var(--ui-text-muted);
+}
+.cell {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+.cell-glyph {
+  display: grid;
+  place-items: center;
+  inline-size: 1.5rem;
+  block-size: 1.5rem;
+  border-radius: calc(var(--ui-radius) - 4px);
+  background: var(--ui-muted);
+  font-size: 0.75rem;
+}
+.cell-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+.cell-hint {
+  font-size: 0.75rem;
+  color: var(--ui-text-muted);
+}
+</style>

--- a/docs/src/demos/PullToRefresh/03-InsideAnExistingScrollArea.vue
+++ b/docs/src/demos/PullToRefresh/03-InsideAnExistingScrollArea.vue
@@ -1,0 +1,55 @@
+<template>
+  <section class="demo">
+    <h3>Inside an existing scroll area</h3>
+    <p class="note">
+      Pass <code>:scroll-el</code> when the scrolling already happens on an ancestor. The component
+      stays a thin wrapper and never takes over that element's <code>overflow</code>. The gesture
+      engages only while that element is scrolled to the very top — scroll down and it's an ordinary
+      list again.
+    </p>
+    <div ref="scroller" class="ptr-scroller">
+      <PullToRefresh :on-refresh="refresh" :scroll-el="scroller">
+        <ul class="ptr-list">
+          <li v-for="rowLabel in rows" :key="rowLabel" class="ptr-row">{{ rowLabel }}</li>
+        </ul>
+      </PullToRefresh>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { shallowRef, useTemplateRef } from 'vue'
+import { PullToRefresh } from 'vael-ui'
+
+const scroller = useTemplateRef<HTMLElement>('scroller')
+const rows = shallowRef(Array.from({ length: 24 }, (_, i) => `Row ${i + 1}`))
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+async function refresh() {
+  await wait(1200)
+  rows.value = [`Refreshed @ ${new Date().toLocaleTimeString()}`, ...rows.value]
+}
+</script>
+
+<style scoped>
+.ptr-scroller {
+  block-size: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius-surface);
+  margin-block-end: 1.5rem;
+}
+.ptr-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.ptr-row {
+  padding: 0.75rem 1rem;
+  border-block-end: 1px solid var(--ui-border);
+  font-size: 0.875rem;
+}
+</style>

--- a/packages/ui/src/components/Menu/Menu.vue
+++ b/packages/ui/src/components/Menu/Menu.vue
@@ -86,9 +86,9 @@
                   </slot>
                 </component>
                 <!-- Teleported to ancestor to stay in same DOM subtree for outside-click detection.
-                     Forwards #item so a custom row override keeps applying at every nesting depth
-                     instead of silently reverting to the default row past the first submenu level. -->
-                <Menu
+                     #item is forwarded through `relayItemSlot` so a custom row keeps applying at
+                     every nesting depth instead of reverting to the default row past level one. -->
+                <MenuSelf
                   v-if="entry.items && positionerEl"
                   :items="entry.items"
                   :trigger-el="rowEls[i]"
@@ -103,9 +103,9 @@
                   @mouseleave="onSubmenuPanelMouseLeave(i)"
                 >
                   <template v-if="$slots.item" #item="{ item: nestedItem }">
-                    <slot name="item" :item="nestedItem as T" />
+                    <component :is="relayItemSlot" :item="nestedItem as T" />
                   </template>
-                </Menu>
+                </MenuSelf>
               </template>
             </template>
           </div>
@@ -212,7 +212,23 @@ export interface MenuProps<T extends MenuItemData = MenuItemData> {
 <script setup lang="ts" generic="T extends MenuItemData = MenuItemData">
 import './Menu.css'
 import '../shared/tokens.css'
-import { computed, inject, nextTick, reactive, useTemplateRef, watch, watchEffect } from 'vue'
+import {
+  computed,
+  inject,
+  nextTick,
+  reactive,
+  useSlots,
+  useTemplateRef,
+  watch,
+  watchEffect,
+} from 'vue'
+import type { FunctionalComponent, VNodeChild } from 'vue'
+// Explicit self-import for the recursive submenu (see the template). `<Menu>` by name relies on
+// `resolveComponent('Menu', true)`, which returns the bare string — not the component — inside a
+// Vapor render, so the submenu renders as a stray `<menu>` element with its props dropped. The
+// circular import resolves fine: the default export is defined by instantiation time, long after
+// this module finishes evaluating.
+import MenuSelf from './Menu.vue'
 import { usePopover } from '../../composables/usePopover'
 import type { PopoverOpenChangeDetails } from '../../composables/usePopover'
 import { useMenu } from '../../composables/useMenu'
@@ -268,6 +284,14 @@ defineSlots<{
   /** Below the item list, outside its scroll region — stays put while `items` scrolls above it. */
   footer(): unknown
 }>()
+
+const slots = useSlots()
+
+// Renders the consumer's own #item slot for a nested submenu row. Captured from THIS instance
+// here, so forwarding it into the child <Menu> (see the template) can't turn into a self-call —
+// a bare `<slot name="item">` there re-resolves against the submenu under the Vapor compiler.
+const relayItemSlot: FunctionalComponent<{ item: T }> = (relayProps) =>
+  slots.item?.(relayProps) as VNodeChild
 
 function isSeparator(entry: MenuEntry<T>): entry is MenuSeparator {
   return (entry as MenuSeparator).type === 'separator'

--- a/packages/ui/src/composables/usePullToRefresh.ts
+++ b/packages/ui/src/composables/usePullToRefresh.ts
@@ -1,4 +1,4 @@
-import { computed, onScopeDispose, shallowRef, toValue, watch } from 'vue'
+import { computed, onScopeDispose, shallowRef, toValue } from 'vue'
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
 import type { ElRef } from './dom'
@@ -38,6 +38,17 @@ function dampen(overshoot: number): number {
   return DAMPEN_FACTOR * Math.log(1 + overshoot / DAMPEN_FACTOR)
 }
 
+/*
+  Touch events, not Pointer Events, drive the pull.
+
+  Suppressing the native scroll / overscroll-bounce for the exact span of a downward drag at
+  `scrollTop 0` needs `preventDefault()` on a NON-passive `touchmove` — that is the only call a
+  browser actually honours for this, on iOS Safari and Android Chrome alike. `preventDefault()`
+  on a `pointermove` is spec'd not to affect scrolling at all, and the alternative (toggling
+  `touch-action` from a `scroll` listener) always lags the moment you settle back at the top by
+  an event or two, so a swipe there scrolls instead of pulling. Pointer Events stay wired up for
+  a real mouse only, so the docs demo still drags on desktop.
+*/
 export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRefreshReturn {
   const state = shallowRef<PullToRefreshState>('idle')
   const pullDistance = shallowRef(0)
@@ -54,10 +65,12 @@ export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRef
 
   const progress = computed(() => Math.min(1, pullDistance.value / thresholdValue()))
 
-  let pointerId: number | null = null
+  type DragSource = { kind: 'touch' | 'pointer'; id: number }
+  let drag: DragSource | null = null
   let startY = 0
   let startTime = 0
   let dragging = false
+  let captured = false
   let refreshToken: symbol | null = null
   let doneTimer: ReturnType<typeof setTimeout> | undefined
 
@@ -94,36 +107,31 @@ export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRef
     return startRefresh()
   }
 
-  function onPointerDown(event: PointerEvent) {
+  /** Arms a drag if the scroll box is at the top; returns whether it took. */
+  function begin(y: number): boolean {
     const el = options.scrollEl.value
-    if (!el || el.scrollTop !== 0 || pointerId !== null) return
-    pointerId = event.pointerId
-    startY = event.clientY
+    if (!el || el.scrollTop !== 0 || drag !== null) return false
+    startY = y
     startTime = performance.now()
     dragging = false
+    captured = false
+    return true
   }
 
-  function onPointerMove(event: PointerEvent) {
-    if (pointerId === null || event.pointerId !== pointerId) return
+  /**
+   * Feeds a move into the state machine. `'pull'` means the caller should keep the browser out
+   * of it (`preventDefault`); `'release'` means the scroll box left the top and the gesture is
+   * the page's now; `'ignore'` is an upward/flat move before the pull has committed.
+   */
+  function applyMove(y: number): 'pull' | 'release' | 'ignore' {
     const el = options.scrollEl.value
-    if (!el) return
-
+    if (!el) return 'release'
     if (!dragging) {
-      if (event.clientY - startY <= 0 || el.scrollTop !== 0) {
-        if (el.scrollTop !== 0) pointerId = null
-        return
-      }
+      if (el.scrollTop !== 0) return 'release'
+      if (y - startY <= 0) return 'ignore'
       dragging = true
-      // Best-effort tracking in case pointer strays outside bounds.
-      try {
-        el.setPointerCapture(pointerId)
-      } catch {
-        // Capture can fail for synthetic events; not fatal.
-      }
     }
-
-    event.preventDefault()
-    const delta = Math.max(0, event.clientY - startY)
+    const delta = Math.max(0, y - startY)
     const max = maxPullValue()
     pullDistance.value = delta <= max ? delta : max + dampen(delta - max)
     state.value =
@@ -132,10 +140,10 @@ export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRef
         : pullDistance.value >= thresholdValue()
           ? 'ready'
           : 'pulling'
+    return 'pull'
   }
 
   function endDrag(commit: boolean) {
-    if (pointerId === null) return
     const wasDragging = dragging
     const wasReady = state.value === 'ready'
     const elapsed = Math.max(1, performance.now() - startTime)
@@ -143,53 +151,99 @@ export function usePullToRefresh(options: UsePullToRefreshOptions): UsePullToRef
     const wasFastFlick =
       velocity > VELOCITY_THRESHOLD &&
       pullDistance.value >= thresholdValue() * VELOCITY_MIN_DISTANCE_FRACTION
-    pointerId = null
+    drag = null
     dragging = false
+    captured = false
     if (!wasDragging) return
     if (commit && (wasReady || wasFastFlick)) startRefresh()
     else settleZero()
   }
 
-  function onPointerUp(event: PointerEvent) {
-    if (pointerId === null || event.pointerId !== pointerId) return
+  /** Hand the gesture back mid-drag (the scroll box scrolled away from the top). */
+  function abandonDrag() {
+    drag = null
+    dragging = false
+    captured = false
+    if (state.value === 'pulling' || state.value === 'ready') settleZero()
+  }
+
+  function findTouch(list: TouchList, id: number): Touch | null {
+    for (let i = 0; i < list.length; i++) {
+      if (list[i]!.identifier === id) return list[i]!
+    }
+    return null
+  }
+
+  function onTouchStart(event: TouchEvent) {
+    if (drag !== null || event.touches.length !== 1) return
+    const touch = event.touches[0]!
+    if (begin(touch.clientY)) drag = { kind: 'touch', id: touch.identifier }
+  }
+
+  function onTouchMove(event: TouchEvent) {
+    if (drag?.kind !== 'touch') return
+    const touch = findTouch(event.touches, drag.id)
+    if (!touch) return
+    const result = applyMove(touch.clientY)
+    if (result === 'release') abandonDrag()
+    else if (result === 'pull' && event.cancelable) event.preventDefault()
+  }
+
+  function onTouchEnd(event: TouchEvent) {
+    if (drag?.kind !== 'touch' || !findTouch(event.changedTouches, drag.id)) return
     endDrag(true)
   }
 
-  function onPointerCancel(event: PointerEvent) {
-    if (pointerId === null || event.pointerId !== pointerId) return
-    endDrag(false)
+  function onTouchCancel() {
+    if (drag?.kind === 'touch') endDrag(false)
   }
 
+  function onPointerDown(event: PointerEvent) {
+    // Touch goes through the touch handlers, where `preventDefault` on a non-passive
+    // `touchmove` can actually hold back the native scroll.
+    if (event.pointerType === 'touch' || drag !== null) return
+    if (begin(event.clientY)) drag = { kind: 'pointer', id: event.pointerId }
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (drag?.kind !== 'pointer' || event.pointerId !== drag.id) return
+    const result = applyMove(event.clientY)
+    if (result === 'release') {
+      abandonDrag()
+      return
+    }
+    if (result !== 'pull') return
+    event.preventDefault()
+    if (!captured) {
+      try {
+        options.scrollEl.value?.setPointerCapture(drag.id)
+        captured = true
+      } catch {
+        // Capture can fail for synthetic events; not fatal.
+      }
+    }
+  }
+
+  function onPointerUp(event: PointerEvent) {
+    if (drag?.kind === 'pointer' && event.pointerId === drag.id) endDrag(true)
+  }
+
+  function onPointerCancel(event: PointerEvent) {
+    if (drag?.kind === 'pointer' && event.pointerId === drag.id) endDrag(false)
+  }
+
+  useEventListener(options.scrollEl, 'touchstart', onTouchStart, { passive: true })
+  useEventListener(options.scrollEl, 'touchmove', onTouchMove, { passive: false })
+  useEventListener(options.scrollEl, 'touchend', onTouchEnd, { passive: true })
+  useEventListener(options.scrollEl, 'touchcancel', onTouchCancel, { passive: true })
   useEventListener(options.scrollEl, 'pointerdown', onPointerDown)
   useEventListener(options.scrollEl, 'pointermove', onPointerMove, { passive: false })
   useEventListener(options.scrollEl, 'pointerup', onPointerUp)
   useEventListener(options.scrollEl, 'pointercancel', onPointerCancel)
 
-  // A gesture's touch-action is decided by the browser before any JS runs on its first move —
-  // setting `touch-action: none` from a pointerdown handler is always one event too late. Instead,
-  // keep it settled ahead of time from scroll position alone: blocking only the native downward
-  // pan at scrollTop 0 leaves our own pointermove free to claim that exact drag, while every other
-  // direction (and all scrolling once away from the top) stays untouched.
-  let lastEl: HTMLElement | null = null
-  function updateTouchAction() {
-    const el = options.scrollEl.value
-    if (el) el.style.touchAction = el.scrollTop === 0 ? 'pan-x pan-up' : ''
-  }
-  useEventListener(options.scrollEl, 'scroll', updateTouchAction, { passive: true })
-  watch(
-    options.scrollEl,
-    (el) => {
-      if (lastEl && lastEl !== el) lastEl.style.touchAction = ''
-      lastEl = el
-      updateTouchAction()
-    },
-    { immediate: true },
-  )
-
   onScopeDispose(() => {
     refreshToken = null
     clearTimeout(doneTimer)
-    if (lastEl) lastEl.style.touchAction = ''
   })
 
   return { state, pullDistance, progress, refresh }

--- a/packages/ui/tests/fixtures/MenuSubmenuItemSlotFixture.vue
+++ b/packages/ui/tests/fixtures/MenuSubmenuItemSlotFixture.vue
@@ -1,0 +1,39 @@
+<template>
+  <output data-testid="selected">{{ selected }}</output>
+  <Menu :items="items" @select="selected = $event.value ?? ''">
+    <template #trigger>
+      <button data-testid="trigger">open menu</button>
+    </template>
+    <!-- Custom row markup that must keep applying at EVERY submenu depth, not
+         revert to the default row past level one. The `mark:` prefix is what
+         the test looks for. -->
+    <template #item="{ item }">
+      <span class="mark-row">mark:{{ item.label }}</span>
+    </template>
+  </Menu>
+</template>
+
+<script setup lang="ts">
+import { shallowRef } from 'vue'
+import Menu from '../../src/components/Menu/Menu.vue'
+import type { MenuEntry } from '../../src/components/Menu/Menu.vue'
+
+const items: MenuEntry[] = [
+  { label: 'Cut', value: 'cut' },
+  {
+    label: 'Share',
+    items: [
+      { label: 'Copy Link', value: 'copy-link' },
+      {
+        label: 'Social',
+        items: [
+          { label: 'Twitter', value: 'twitter' },
+          { label: 'Mastodon', value: 'mastodon' },
+        ],
+      },
+    ],
+  },
+]
+
+const selected = shallowRef('')
+</script>

--- a/packages/ui/tests/menu-item-slot-submenu.test.ts
+++ b/packages/ui/tests/menu-item-slot-submenu.test.ts
@@ -1,0 +1,67 @@
+import '../src/style.css'
+import { userEvent } from 'vitest/browser'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import MenuSubmenuItemSlotFixture from './fixtures/MenuSubmenuItemSlotFixture.vue'
+
+beforeEach(() => {
+  for (const el of document.querySelectorAll('.ui-menu-positioner')) el.remove()
+})
+
+function rowByText(text: string): HTMLElement | null {
+  return (
+    Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+      (el) => el.textContent?.trim() === text,
+    ) ?? null
+  )
+}
+
+function focusedText(): string | undefined {
+  return document.activeElement?.textContent?.trim()
+}
+
+// A custom #item slot must keep rendering its own markup inside nested submenus,
+// not silently fall back to the default row past the first level. Under the Vapor
+// compiler a naive `<slot name="item">` forwarded into the child <Menu> resolves
+// against the child and calls itself forever; this is the regression guard for
+// both the fallback-to-default bug and that recursion.
+test('a custom #item slot keeps applying at every submenu depth', async () => {
+  const screen = render(MenuSubmenuItemSlotFixture)
+  await screen.getByTestId('trigger').click()
+
+  // Level 0 — the root list.
+  await vi.waitFor(() => expect(focusedText()).toBe('mark:Cut'))
+  expect(rowByText('mark:Share')).not.toBeNull()
+
+  // Level 1 — open "Share".
+  await userEvent.keyboard('{ArrowDown}') // -> Share
+  await vi.waitFor(() => expect(focusedText()).toBe('mark:Share'))
+  await userEvent.keyboard('{ArrowRight}') // open its submenu
+  await vi.waitFor(() => expect(focusedText()).toBe('mark:Copy Link'))
+  expect(rowByText('mark:Social')).not.toBeNull()
+
+  // Level 2 — open "Social". This is the depth the old build reverted to the
+  // default row (or, in Vapor, blew the stack).
+  await userEvent.keyboard('{ArrowDown}') // -> Social
+  await vi.waitFor(() => expect(focusedText()).toBe('mark:Social'))
+  await userEvent.keyboard('{ArrowRight}')
+  await vi.waitFor(() => expect(rowByText('mark:Twitter')).not.toBeNull())
+  expect(rowByText('mark:Mastodon')).not.toBeNull()
+})
+
+test('selecting a deep custom row still bubbles its value and closes the chain', async () => {
+  const screen = render(MenuSubmenuItemSlotFixture)
+  await screen.getByTestId('trigger').click()
+  await vi.waitFor(() => expect(focusedText()).toBe('mark:Cut'))
+
+  await userEvent.keyboard('{ArrowDown}') // -> Share
+  await userEvent.keyboard('{ArrowRight}') // open Share
+  await vi.waitFor(() => expect(focusedText()).toBe('mark:Copy Link'))
+  await userEvent.keyboard('{ArrowDown}') // -> Social
+  await userEvent.keyboard('{ArrowRight}') // open Social
+  await vi.waitFor(() => expect(rowByText('mark:Twitter')).not.toBeNull())
+
+  rowByText('mark:Twitter')!.click()
+  await expect.element(screen.getByTestId('selected')).toHaveTextContent('twitter')
+  expect(rowByText('mark:Cut')).toBeNull()
+})

--- a/packages/ui/tests/pull-to-refresh.test.ts
+++ b/packages/ui/tests/pull-to-refresh.test.ts
@@ -44,6 +44,41 @@ async function drag(el: Element, startY: number, endY: number, ms: number) {
   el.dispatchEvent(new PointerEvent('pointerup', { clientY: endY, pointerId, bubbles: true }))
 }
 
+function makeTouch(target: EventTarget, y: number, id = 1): Touch {
+  return new Touch({
+    identifier: id,
+    target: target as Element,
+    clientX: 0,
+    clientY: y,
+    pageX: 0,
+    pageY: y,
+  })
+}
+
+/** Returns false when the listener called preventDefault() (i.e. it held the native scroll back). */
+function fireTouch(el: Element, type: string, live: Touch[], changed: Touch[]): boolean {
+  return el.dispatchEvent(
+    new TouchEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      touches: live,
+      targetTouches: live,
+      changedTouches: changed,
+    }),
+  )
+}
+
+/** Mirrors drag() but through TouchEvents — the path real mobile input actually takes. */
+async function touchDrag(el: Element, startY: number, endY: number, ms: number) {
+  const start = makeTouch(el, startY)
+  fireTouch(el, 'touchstart', [start], [start])
+  await new Promise((r) => setTimeout(r, ms))
+  const move = makeTouch(el, endY)
+  const notPrevented = fireTouch(el, 'touchmove', [move], [move])
+  fireTouch(el, 'touchend', [], [makeTouch(el, endY)])
+  return { movePrevented: notPrevented === false }
+}
+
 test('a slow pull below threshold releases back to idle without calling onRefresh', async () => {
   const onRefresh = vi.fn().mockResolvedValue(undefined)
   render(PullToRefreshFixture, { props: { onRefresh } })
@@ -147,4 +182,97 @@ test('an onRefresh that rejects still settles back to idle instead of getting st
   await vi.waitFor(() => expect(state()).toBe('idle'), { timeout: 2000 })
 
   expect(onRefresh).toHaveBeenCalledTimes(1)
+})
+
+// ── Touch input ─────────────────────────────────────────────────────────────
+// The engine is touch-first: a non-passive `touchmove` + `preventDefault()` is
+// the only thing a browser actually honours to hold back the native scroll /
+// overscroll-bounce for the span of a pull. These cover that path directly.
+
+test('a touch pull past threshold walks pulling -> ready -> loading -> done -> idle and calls onRefresh once', async () => {
+  const onRefresh = vi.fn().mockResolvedValue(undefined)
+  render(PullToRefreshFixture, { props: { onRefresh } })
+  await settle()
+
+  const t0 = makeTouch(root(), 20)
+  fireTouch(root(), 'touchstart', [t0], [t0])
+  await new Promise((r) => setTimeout(r, 30))
+
+  fireTouch(root(), 'touchmove', [makeTouch(root(), 60)], [makeTouch(root(), 60)]) // delta 40
+  await vi.waitFor(() => expect(state()).toBe('pulling'))
+
+  const t2 = makeTouch(root(), 110) // delta 90
+  fireTouch(root(), 'touchmove', [t2], [t2])
+  await vi.waitFor(() => expect(state()).toBe('ready'))
+
+  fireTouch(root(), 'touchend', [], [t2])
+  await vi.waitFor(() => expect(['loading', 'done']).toContain(state()))
+  await vi.waitFor(() => expect(state()).toBe('idle'), { timeout: 1500 })
+
+  expect(onRefresh).toHaveBeenCalledTimes(1)
+})
+
+test('a slow touch pull below threshold releases back to idle without calling onRefresh', async () => {
+  const onRefresh = vi.fn().mockResolvedValue(undefined)
+  render(PullToRefreshFixture, { props: { onRefresh } })
+  await settle()
+
+  // delta 30 over 400ms — under both the distance threshold and the flick gate.
+  await touchDrag(root(), 20, 50, 400)
+
+  await vi.waitFor(() => expect(state()).toBe('idle'))
+  await vi.waitFor(() => expect(zoneHeight()).toBeCloseTo(0, 0))
+  expect(onRefresh).not.toHaveBeenCalled()
+})
+
+test('touchmove during a pull is preventDefaulted, so the container cannot scroll under it', async () => {
+  const onRefresh = vi.fn().mockResolvedValue(undefined)
+  render(PullToRefreshFixture, { props: { onRefresh } })
+  await settle()
+
+  const start = makeTouch(root(), 20)
+  fireTouch(root(), 'touchstart', [start], [start])
+  await new Promise((r) => setTimeout(r, 10))
+
+  const move = makeTouch(root(), 70) // downward, from the top
+  const notPrevented = fireTouch(root(), 'touchmove', [move], [move])
+  fireTouch(root(), 'touchend', [], [move])
+
+  expect(notPrevented).toBe(false) // preventDefault() ran
+})
+
+test('a touch drag while scrollTop > 0 never engages and never preventDefaults — pull-to-refresh is top-only', async () => {
+  const onRefresh = vi.fn().mockResolvedValue(undefined)
+  render(PullToRefreshFixture, { props: { onRefresh } })
+  await settle()
+
+  root().scrollTop = 100
+  const start = makeTouch(root(), 20)
+  fireTouch(root(), 'touchstart', [start], [start])
+  await new Promise((r) => setTimeout(r, 10))
+  const move = makeTouch(root(), 140)
+  const notPrevented = fireTouch(root(), 'touchmove', [move], [move])
+  fireTouch(root(), 'touchend', [], [move])
+
+  expect(notPrevented).toBe(true) // native scroll keeps the gesture
+  expect(state()).toBe('idle')
+  expect(zoneHeight()).toBeCloseTo(0, 0)
+  expect(onRefresh).not.toHaveBeenCalled()
+})
+
+test('a touch that starts as an upward move at the top does not engage', async () => {
+  const onRefresh = vi.fn().mockResolvedValue(undefined)
+  render(PullToRefreshFixture, { props: { onRefresh } })
+  await settle()
+
+  const start = makeTouch(root(), 80)
+  fireTouch(root(), 'touchstart', [start], [start])
+  await new Promise((r) => setTimeout(r, 10))
+  const move = makeTouch(root(), 40) // upward
+  const notPrevented = fireTouch(root(), 'touchmove', [move], [move])
+  fireTouch(root(), 'touchend', [], [move])
+
+  expect(notPrevented).toBe(true)
+  expect(state()).toBe('idle')
+  expect(onRefresh).not.toHaveBeenCalled()
 })

--- a/packages/vapor-ui/tests/fixtures/MenuItemSlotRoot.vue
+++ b/packages/vapor-ui/tests/fixtures/MenuItemSlotRoot.vue
@@ -1,0 +1,43 @@
+<template>
+  <Menu :items="items" @select="onSelect">
+    <template #trigger>
+      <button data-testid="vapor-menu-trigger">Open</button>
+    </template>
+    <!-- Custom row markup. Under the old Vapor build this `#item`, forwarded
+         into each nested submenu, re-resolved against the submenu instance and
+         called itself until the stack blew. Nothing below should render at all
+         if that regresses. -->
+    <template #item="{ item }">
+      <span data-mark>mark:{{ item.label }}</span>
+    </template>
+  </Menu>
+  <output data-testid="vapor-menu-selected">{{ selected }}</output>
+</template>
+
+<script setup lang="ts" vapor>
+import { shallowRef } from 'vue'
+import { Menu } from 'vael-ui/vapor'
+import type { MenuEntry, MenuItemData } from 'vael-ui/vapor'
+
+const items: MenuEntry[] = [
+  { label: 'Cut', value: 'cut' },
+  {
+    label: 'Share',
+    items: [
+      { label: 'Copy Link', value: 'copy-link' },
+      {
+        label: 'Social',
+        items: [
+          { label: 'Twitter', value: 'twitter' },
+          { label: 'Mastodon', value: 'mastodon' },
+        ],
+      },
+    ],
+  },
+]
+
+const selected = shallowRef('')
+function onSelect(item: MenuItemData) {
+  selected.value = String(item.value ?? '')
+}
+</script>

--- a/packages/vapor-ui/tests/menu-item-slot-recursion.test.ts
+++ b/packages/vapor-ui/tests/menu-item-slot-recursion.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The built Vapor <Menu> forwarding a custom #item slot down through nested
+ * submenus. A bare `<slot name="item">` in that forward compiles, under the
+ * Vapor compiler, to a `createSlot('item')` that re-resolves against the
+ * SUBMENU instance — whose own #item is that same forward — so it recurses
+ * until the stack blows and nothing renders. The fix relays the parent's
+ * captured slot through `<component :is>` instead. Consumes ../ui/dist/vapor,
+ * so run `pnpm build` first.
+ */
+import { expect, test, vi } from 'vitest'
+import { createVaporApp } from 'vue'
+import MenuItemSlotRoot from './fixtures/MenuItemSlotRoot.vue'
+
+function mount() {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const app = createVaporApp(MenuItemSlotRoot)
+  app.mount(host)
+  return {
+    app,
+    host,
+    cleanup() {
+      app.unmount()
+      host.remove()
+      for (const el of document.querySelectorAll('.ui-menu-positioner')) el.remove()
+    },
+  }
+}
+
+function rowByText(text: string): HTMLElement | null {
+  return (
+    Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+      (el) => el.textContent?.trim() === text,
+    ) ?? null
+  )
+}
+
+/** Opens a submenu by activating its trigger row, the way a real click does. */
+async function expandRow(text: string) {
+  const row = await vi.waitFor(() => {
+    const el = rowByText(text)
+    if (!el) throw new Error(`row "${text}" not found`)
+    return el
+  })
+  row.click()
+}
+
+test('a custom #item slot survives being forwarded through nested submenus (no recursion, no fallback)', async () => {
+  const { host, cleanup } = mount()
+  try {
+    host.querySelector<HTMLElement>('[data-testid="vapor-menu-trigger"]')!.click()
+
+    // Level 0 — root list, rendered through the custom slot.
+    await vi.waitFor(() => expect(rowByText('mark:Cut')).not.toBeNull())
+    expect(rowByText('mark:Share')).not.toBeNull()
+
+    // Level 1 — opening "Share" forces the first forwarded submenu to render
+    // its rows. The old Vapor build blew the stack right here.
+    await expandRow('mark:Share')
+    await vi.waitFor(() => expect(rowByText('mark:Copy Link')).not.toBeNull())
+    expect(rowByText('mark:Social')).not.toBeNull()
+
+    // Level 2 — still the consumer's markup, not a reverted default row.
+    await expandRow('mark:Social')
+    await vi.waitFor(() => expect(rowByText('mark:Twitter')).not.toBeNull())
+    expect(rowByText('mark:Mastodon')).not.toBeNull()
+
+    // A deep leaf still selects and bubbles its value.
+    rowByText('mark:Twitter')!.click()
+    await vi.waitFor(() =>
+      expect(document.querySelector('[data-testid="vapor-menu-selected"]')!.textContent).toBe(
+        'twitter',
+      ),
+    )
+  } finally {
+    cleanup()
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,17 @@ settings:
 overrides:
   brace-expansion: '>=5.0.8'
   vue: 3.6.0-rc.7
+  '@vue/compiler-core': 3.6.0-rc.7
+  '@vue/compiler-dom': 3.6.0-rc.7
+  '@vue/compiler-sfc': 3.6.0-rc.7
+  '@vue/compiler-ssr': 3.6.0-rc.7
+  '@vue/compiler-vapor': 3.6.0-rc.7
+  '@vue/reactivity': 3.6.0-rc.7
+  '@vue/runtime-core': 3.6.0-rc.7
+  '@vue/runtime-dom': 3.6.0-rc.7
+  '@vue/runtime-vapor': 3.6.0-rc.7
+  '@vue/server-renderer': 3.6.0-rc.7
+  '@vue/shared': 3.6.0-rc.7
 
 importers:
 
@@ -80,7 +91,7 @@ importers:
         version: 4.15.1(vue@3.6.0-rc.7(typescript@6.0.3))
       vite-ssg:
         specifier: ^28.3.0
-        version: 28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)))(vue@3.6.0-rc.7(typescript@6.0.3))
+        version: 28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.6.0-rc.7)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)))(vue@3.6.0-rc.7(typescript@6.0.3))
       vue:
         specifier: 3.6.0-rc.7
         version: 3.6.0-rc.7(typescript@6.0.3)
@@ -89,7 +100,7 @@ importers:
         version: 11.4.8(vue@3.6.0-rc.7(typescript@6.0.3))
       vue-router:
         specifier: ^5.3.0
-        version: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
+        version: 5.3.0(@vue/compiler-sfc@3.6.0-rc.7)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
@@ -157,7 +168,7 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0(supports-color@10.2.2))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       vitest-browser-vue:
         specifier: ^2.1.0
-        version: 2.1.0(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.7(typescript@6.0.3))
+        version: 2.1.0(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.6.0-rc.7)(vitest@4.1.10)(vue@3.6.0-rc.7(typescript@6.0.3))
       vue:
         specifier: 3.6.0-rc.7
         version: 3.6.0-rc.7(typescript@6.0.3)
@@ -225,7 +236,7 @@ importers:
     devDependencies:
       nuxt:
         specifier: ^4.5.2
-        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0)
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.6.0-rc.7)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0)
 
   playground/vapor:
     dependencies:
@@ -302,7 +313,7 @@ importers:
         version: 11.4.8(vue@3.6.0-rc.7(typescript@6.0.3))
       vue-router:
         specifier: ^5.3.0
-        version: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
+        version: 5.3.0(@vue/compiler-sfc@3.6.0-rc.7)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
@@ -1997,35 +2008,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.40':
-    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
-
-  '@vue/compiler-core@3.5.41':
-    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
-
   '@vue/compiler-core@3.6.0-rc.7':
     resolution: {integrity: sha512-8WWomL1m/mLayJEeTgAJdAYm+f7FIiPbFmHqHdSSFFIgBrNvyMwGsXcCP3fgJjiJ3E+/kcpFYvdyV/iY2i+eEQ==}
-
-  '@vue/compiler-dom@3.5.40':
-    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
-
-  '@vue/compiler-dom@3.5.41':
-    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
 
   '@vue/compiler-dom@3.6.0-rc.7':
     resolution: {integrity: sha512-ACdPq6xoMxraG0aMJUqo1ZeLTgZoatLOHvTbvqlsDywhcPueq8WyWONftAl6SzU9ooE/fYJbNUSRYEms22xHWQ==}
 
-  '@vue/compiler-sfc@3.5.41':
-    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
-
   '@vue/compiler-sfc@3.6.0-rc.7':
     resolution: {integrity: sha512-MNxvA8ZlajbE+8+syBGXBRsFJIevyEEl085ibp3aqmr2FWJOetpW+aARlJpEJxkzUisz7aV7AJMJHnOL1Ccrhg==}
-
-  '@vue/compiler-ssr@3.5.40':
-    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
-
-  '@vue/compiler-ssr@3.5.41':
-    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
 
   '@vue/compiler-ssr@3.6.0-rc.7':
     resolution: {integrity: sha512-M+gevHy3u+/Bt9id2ebvILwZKmFOvk+nfRPdG60xxDfICJlUC1fKWEsiPldz9QngjjOtaI1CP2/0DGhMCueH1Q==}
@@ -2062,23 +2052,11 @@ packages:
   '@vue/language-core@3.3.10':
     resolution: {integrity: sha512-CR7ByBbgPHqhxrioKPOcZBqttaozzLNwtkCzXQ+uF8gLPHnUe03srPnGpdtHD3zp+bq5iyVkZ1WNx7W564RPwg==}
 
-  '@vue/reactivity@3.5.40':
-    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
-
-  '@vue/reactivity@3.5.41':
-    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
-
   '@vue/reactivity@3.6.0-rc.7':
     resolution: {integrity: sha512-SaFGEMt25HCbLPIJqciStDDwgesfZOzlRiZPI5V9Jlchuv0u+nbNE8ei/HV3pqrnXJUJFHt4JwkeXHsDs56VnA==}
 
-  '@vue/runtime-core@3.5.40':
-    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
-
   '@vue/runtime-core@3.6.0-rc.7':
     resolution: {integrity: sha512-L5atC1fUiMu0oMcjvb1LHGSwF8j5o8GmINC4SsDO+W78ztsiBrwRfjsyShpubNDnit4aNm7hzTJKZ8WB51KITQ==}
-
-  '@vue/runtime-dom@3.5.40':
-    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
 
   '@vue/runtime-dom@3.6.0-rc.7':
     resolution: {integrity: sha512-TqpIk49kcrpVmV4kacijO8EtEblS908mLBksa0lQ2/D59mJbUcGuhqxqE/akI/q7eSTWFdal1jcmXrPF4iQYFA==}
@@ -2088,17 +2066,8 @@ packages:
     peerDependencies:
       '@vue/runtime-dom': 3.6.0-rc.7
 
-  '@vue/server-renderer@3.5.40':
-    resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
-
   '@vue/server-renderer@3.6.0-rc.7':
     resolution: {integrity: sha512-0c7XLrVUuQhPA1DrB40y+DrjWIEnpIu6Eq9NeRmeFl3usdBoVwvY5NCTAIEOH/bQskjeDRU6svnQyKMWKs7M+g==}
-
-  '@vue/shared@3.5.40':
-    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
-
-  '@vue/shared@3.5.41':
-    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
 
   '@vue/shared@3.6.0-rc.7':
     resolution: {integrity: sha512-KOGkvUjgtrBtG2YEr+eB3LfHSdljkPUvV51fpnh7VUiTtCo1gBkYykgtg6/mFwyA+BhCsTDwEP87T6zdjtmOug==}
@@ -2106,8 +2075,8 @@ packages:
   '@vue/test-utils@2.4.11':
     resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
     peerDependencies:
-      '@vue/compiler-dom': 3.x
-      '@vue/server-renderer': 3.x
+      '@vue/compiler-dom': 3.6.0-rc.7
+      '@vue/server-renderer': 3.6.0-rc.7
       vue: 3.6.0-rc.7
     peerDependenciesMeta:
       '@vue/server-renderer':
@@ -5378,7 +5347,7 @@ packages:
     resolution: {integrity: sha512-a2PBXX9yfkS58JzSJALUffgDa09lEzKmCcEnLaepoIr88L+9hEnsgEQkcadJGID+vtHa0gFpVo064zmylA9fcg==}
     peerDependencies:
       '@pinia/colada': '>=0.21.2'
-      '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
+      '@vue/compiler-sfc': 3.6.0-rc.7
       pinia: ^3.0.4 || ^4.0.2
       vite: ^7.3.0 || ^8.0.0
       vue: 3.6.0-rc.7
@@ -6060,7 +6029,7 @@ snapshots:
     dependencies:
       '@dxup/unimport': 0.1.2
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
-      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-dom': 3.6.0-rc.7
       chokidar: 5.0.0
       knitwork: 1.3.0
       magic-string: 1.2.0
@@ -6498,12 +6467,12 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.2(2dbf0865b66491d905e98775edc2fe26)':
+  '@nuxt/nitro-server@4.5.2(3b130a432b46bee893be4d6fce20f4a7)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
-      '@vue/shared': 3.5.41
+      '@vue/shared': 3.6.0-rc.7
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
@@ -6517,7 +6486,7 @@ snapshots:
       mocked-exports: 0.1.1
       nitropack: 2.13.4(rolldown@1.2.4)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.6.0-rc.7)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.9
       ohash: 2.0.12
       pathe: 2.0.3
@@ -6586,7 +6555,7 @@ snapshots:
 
   '@nuxt/schema@4.5.2':
     dependencies:
-      '@vue/shared': 3.5.41
+      '@vue/shared': 3.6.0-rc.7
       defu: 6.1.7
       nostics: 1.2.0
       pathe: 2.0.3
@@ -6602,7 +6571,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(880d37d2ae0c51f384bbd7476e462c4b)':
+  '@nuxt/vite-builder@4.5.2(940260108c3312e9e7d23377e0bc2a26)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
@@ -6620,7 +6589,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.6.0-rc.7)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -7368,7 +7337,7 @@ snapshots:
 
   '@vue-macros/common@3.1.4(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.41
+      '@vue/compiler-sfc': 3.6.0-rc.7
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
@@ -7388,7 +7357,7 @@ snapshots:
       '@babel/types': 7.29.8
       '@vue/babel-helper-vue-transform-on': 2.0.1
       '@vue/babel-plugin-resolve-type': 2.0.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@vue/shared': 3.5.41
+      '@vue/shared': 3.6.0-rc.7
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -7401,26 +7370,9 @@ snapshots:
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/parser': 7.29.8
-      '@vue/compiler-sfc': 3.5.41
+      '@vue/compiler-sfc': 3.6.0-rc.7
     transitivePeerDependencies:
       - supports-color
-
-  '@vue/compiler-core@3.5.40':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@vue/shared': 3.5.40
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-    optional: true
-
-  '@vue/compiler-core@3.5.41':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@vue/shared': 3.5.41
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.6.0-rc.7':
     dependencies:
@@ -7430,33 +7382,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.40':
-    dependencies:
-      '@vue/compiler-core': 3.5.40
-      '@vue/shared': 3.5.40
-    optional: true
-
-  '@vue/compiler-dom@3.5.41':
-    dependencies:
-      '@vue/compiler-core': 3.5.41
-      '@vue/shared': 3.5.41
-
   '@vue/compiler-dom@3.6.0-rc.7':
     dependencies:
       '@vue/compiler-core': 3.6.0-rc.7
       '@vue/shared': 3.6.0-rc.7
-
-  '@vue/compiler-sfc@3.5.41':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@vue/compiler-core': 3.5.41
-      '@vue/compiler-dom': 3.5.41
-      '@vue/compiler-ssr': 3.5.41
-      '@vue/shared': 3.5.41
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.26
-      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.6.0-rc.7':
     dependencies:
@@ -7470,17 +7399,6 @@ snapshots:
       magic-string: 0.30.21
       postcss: 8.5.26
       source-map-js: 1.2.1
-
-  '@vue/compiler-ssr@3.5.40':
-    dependencies:
-      '@vue/compiler-dom': 3.5.40
-      '@vue/shared': 3.5.40
-    optional: true
-
-  '@vue/compiler-ssr@3.5.41':
-    dependencies:
-      '@vue/compiler-dom': 3.5.41
-      '@vue/shared': 3.5.41
 
   '@vue/compiler-ssr@3.6.0-rc.7':
     dependencies:
@@ -7537,44 +7455,21 @@ snapshots:
   '@vue/language-core@3.3.10':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.41
-      '@vue/shared': 3.5.41
+      '@vue/compiler-dom': 3.6.0-rc.7
+      '@vue/shared': 3.6.0-rc.7
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
       picomatch: 4.0.5
 
-  '@vue/reactivity@3.5.40':
-    dependencies:
-      '@vue/shared': 3.5.40
-    optional: true
-
-  '@vue/reactivity@3.5.41':
-    dependencies:
-      '@vue/shared': 3.5.41
-
   '@vue/reactivity@3.6.0-rc.7':
     dependencies:
       '@vue/shared': 3.6.0-rc.7
-
-  '@vue/runtime-core@3.5.40':
-    dependencies:
-      '@vue/reactivity': 3.5.40
-      '@vue/shared': 3.5.40
-    optional: true
 
   '@vue/runtime-core@3.6.0-rc.7':
     dependencies:
       '@vue/reactivity': 3.6.0-rc.7
       '@vue/shared': 3.6.0-rc.7
-
-  '@vue/runtime-dom@3.5.40':
-    dependencies:
-      '@vue/reactivity': 3.5.40
-      '@vue/runtime-core': 3.5.40
-      '@vue/shared': 3.5.40
-      csstype: 3.2.3
-    optional: true
 
   '@vue/runtime-dom@3.6.0-rc.7':
     dependencies:
@@ -7589,34 +7484,22 @@ snapshots:
       '@vue/runtime-dom': 3.6.0-rc.7
       '@vue/shared': 3.6.0-rc.7
 
-  '@vue/server-renderer@3.5.40':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.40
-      '@vue/runtime-dom': 3.5.40
-      '@vue/shared': 3.5.40
-    optional: true
-
   '@vue/server-renderer@3.6.0-rc.7':
     dependencies:
       '@vue/compiler-ssr': 3.6.0-rc.7
       '@vue/runtime-dom': 3.6.0-rc.7
       '@vue/shared': 3.6.0-rc.7
 
-  '@vue/shared@3.5.40':
-    optional: true
-
-  '@vue/shared@3.5.41': {}
-
   '@vue/shared@3.6.0-rc.7': {}
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.7(typescript@6.0.3))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.6.0-rc.7)(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-dom': 3.6.0-rc.7
       js-beautify: 1.15.4
       vue: 3.6.0-rc.7(typescript@6.0.3)
       vue-component-type-helpers: 3.3.10
     optionalDependencies:
-      '@vue/server-renderer': 3.5.40
+      '@vue/server-renderer': 3.6.0-rc.7
 
   '@vueuse/core@14.4.0(vue@3.6.0-rc.7(typescript@6.0.3))':
     dependencies:
@@ -9391,18 +9274,18 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0):
+  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.144.0)(@types/node@26.1.1)(@vue/compiler-sfc@3.6.0-rc.7)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.10(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.7(esbuild@0.28.2)(magicast@0.5.4)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(cac@6.7.14)(magicast@0.5.4)(supports-color@10.2.2)
       '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.0)(rolldown@1.2.4)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.2(2dbf0865b66491d905e98775edc2fe26)
+      '@nuxt/nitro-server': 4.5.2(3b130a432b46bee893be4d6fce20f4a7)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.0)(magicast@0.5.4)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(880d37d2ae0c51f384bbd7476e462c4b)
+      '@nuxt/vite-builder': 4.5.2(940260108c3312e9e7d23377e0bc2a26)
       '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
-      '@vue/shared': 3.5.41
+      '@vue/shared': 3.6.0-rc.7
       chokidar: 5.0.0
       compatx: 0.2.0
       consola: 3.4.2
@@ -9452,7 +9335,7 @@ snapshots:
       verkit: 0.3.2
       vue: 3.6.0-rc.7(typescript@6.0.3)
       vue-component-type-helpers: 3.3.10
-      vue-router: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
+      vue-router: 5.3.0(@vue/compiler-sfc@3.6.0-rc.7)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     optionalDependencies:
       '@types/node': 26.1.1
     transitivePeerDependencies:
@@ -10639,7 +10522,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      '@vue/reactivity': 3.5.41
+      '@vue/reactivity': 3.6.0-rc.7
       obug: 2.1.4
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
@@ -10828,7 +10711,7 @@ snapshots:
 
   vite-ssg-sitemap@0.10.0: {}
 
-  vite-ssg@28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)))(vue@3.6.0-rc.7(typescript@6.0.3)):
+  vite-ssg@28.3.0(beasties@0.4.3)(supports-color@10.2.2)(unhead@2.1.17)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-router@5.3.0(@vue/compiler-sfc@3.6.0-rc.7)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)))(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
       '@unhead/dom': 2.1.17(unhead@2.1.17)
       '@unhead/vue': 2.1.17(vue@3.6.0-rc.7(typescript@6.0.3))
@@ -10841,7 +10724,7 @@ snapshots:
       vue: 3.6.0-rc.7(typescript@6.0.3)
     optionalDependencies:
       beasties: 0.4.3
-      vue-router: 5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
+      vue-router: 5.3.0(@vue/compiler-sfc@3.6.0-rc.7)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3))
     transitivePeerDependencies:
       - '@noble/hashes'
       - canvas
@@ -10863,9 +10746,9 @@ snapshots:
       terser: 5.50.0
       yaml: 2.9.0
 
-  vitest-browser-vue@2.1.0(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vitest@4.1.10)(vue@3.6.0-rc.7(typescript@6.0.3)):
+  vitest-browser-vue@2.1.0(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.6.0-rc.7)(vitest@4.1.10)(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
-      '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.5.40)(vue@3.6.0-rc.7(typescript@6.0.3))
+      '@vue/test-utils': 2.4.11(@vue/compiler-dom@3.6.0-rc.7)(@vue/server-renderer@3.6.0-rc.7)(vue@3.6.0-rc.7(typescript@6.0.3))
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0(supports-color@10.2.2))(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       vue: 3.6.0-rc.7(typescript@6.0.3)
     transitivePeerDependencies:
@@ -10939,7 +10822,7 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.6.0-rc.7(typescript@6.0.3)
 
-  vue-router@5.3.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)):
+  vue-router@5.3.0(@vue/compiler-sfc@3.6.0-rc.7)(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.6.0-rc.7(typescript@6.0.3)):
     dependencies:
       '@vue-macros/common': 3.1.4(vue@3.6.0-rc.7(typescript@6.0.3))
       '@vue/devtools-api': 8.2.1
@@ -10959,7 +10842,7 @@ snapshots:
       unplugin-utils: 0.3.2
       vue: 3.6.0-rc.7(typescript@6.0.3)
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.41
+      '@vue/compiler-sfc': 3.6.0-rc.7
       vite: 8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,17 @@ allowBuilds:
 overrides:
   brace-expansion: '>=5.0.8'
   vue: 3.6.0-rc.7
+  '@vue/compiler-core': 3.6.0-rc.7
+  '@vue/compiler-dom': 3.6.0-rc.7
+  '@vue/compiler-sfc': 3.6.0-rc.7
+  '@vue/compiler-ssr': 3.6.0-rc.7
+  '@vue/compiler-vapor': 3.6.0-rc.7
+  '@vue/reactivity': 3.6.0-rc.7
+  '@vue/runtime-core': 3.6.0-rc.7
+  '@vue/runtime-dom': 3.6.0-rc.7
+  '@vue/runtime-vapor': 3.6.0-rc.7
+  '@vue/server-renderer': 3.6.0-rc.7
+  '@vue/shared': 3.6.0-rc.7
 minimumReleaseAgeExclude:
   - '@vue/language-core@3.3.8 || 3.3.10'
   - vue-tsc@3.3.8 || 3.3.10


### PR DESCRIPTION
## 0.3.3 patch

Two things caught while dogfooding 0.3.2 in a real dashboard.

### PullToRefresh: touch-first again

0.3.2 rebuilt the gesture on Pointer Events plus a `touch-action` that got toggled from a `scroll` listener. Neither actually holds back a native pull: `preventDefault()` on a `pointermove` does nothing to scrolling, and re-arming `touch-action` always lags settling back at the top by an event or two. On iOS Safari the pull just doesn't register.

`usePullToRefresh` now uses a non-passive `touchmove` + `preventDefault()` for exactly the span of a downward drag while the scroll box is at `scrollTop === 0` — the one call browsers honour for this — and it mutates no styles on the consumer's scroll element. Pointer events stay wired up for a real mouse only. The gesture engages strictly at the top of the container; anywhere else it's an ordinary scroll.

### Menu: submenus work in the Vapor build

The recursive submenu `<Menu>` was resolved by name. `resolveComponent('Menu', true)` returns the bare string, not the component, inside a Vapor render, so every Vapor submenu came out as a stray `<menu>` element with its props dropped and never opened. It's an explicit self-import now (`import MenuSelf from './Menu.vue'`), which needs no instance context.

A custom `#item` slot also keeps applying at every submenu depth instead of reverting to the default row past level one. It's forwarded through a small relay captured from the parent instance, so under the Vapor compiler it can't re-resolve against the submenu and recurse.

### Also

The whole `@vue/*` toolchain is pinned to `3.6.0-rc.7` in `pnpm.overrides`, not just `vue`. A second copy of `@vue/runtime-vapor` in the tree breaks recursive Vapor components, since self-reference resolves against the wrong instance registry.

### Docs

- Menu: "Custom rows through nested submenus" — a `#item` slot rendering glyph + label + hint, three levels deep.
- PullToRefresh: "Inside an existing scroll area" — `:scroll-el` on an outer scroller, engaging only at the top.

### Tests

- `packages/vapor-ui/tests/menu-item-slot-recursion.test.ts` — drills three submenu levels through a custom `#item` against the built Vapor bundle.
- `packages/ui/tests/menu-item-slot-submenu.test.ts` — the vdom equivalent.
- `pull-to-refresh.test.ts` — five touch-input cases: pull past and under threshold, `touchmove` is preventDefaulted during a pull, a drag while `scrollTop > 0` never engages, an upward-first move never engages.

vael-ui 943 tests, vapor-ui 20 tests, typecheck across all packages, full build with chunk-split check: all pass.
