### PR TITLE
fix(ui): 0.3.4 patch — SwipeToReveal fringe, slot-only edges, reveal progress

### DIFF
--- a/.changeset/fix-0-3-4.md
+++ b/.changeset/fix-0-3-4.md
@@ -1,0 +1,53 @@
+---
+'vael-ui': patch
+---
+
+## Fixes
+
+- **`Button`:** a `v-if`'d `#badge` slot no longer knocks a grid- or `nth-child`-placed button
+  out of position when the first badge appears. Setting `badgePlacement` reserves the wrapper up
+  front so the DOM position is stable, and the button's own `ui.root` / `class` / `style` ride
+  onto that wrapper so class-based targeting keeps hitting the real outer element. A genuinely
+  badge-less button is still a plain element with no wrapper.
+
+- **`Button`:** dropped the always-on `will-change: transform`. It forced every button onto its
+  own compositor layer for the lifetime of the page; the press-scale still animates without it,
+  and a permanently composited button leaked its edges past clipping ancestors (see
+  `SwipeToReveal`).
+
+- **`BottomSheet`:** a horizontal drag that starts inside the scrollable content — a
+  `SwipeToReveal` row, say — is no longer hijacked into a pull-to-dismiss on a few pixels of
+  vertical drift. `useSheetDrag` now runs the same axis-dominance check `SwipeToReveal` already
+  does before promoting a content drag to a dismiss.
+
+- **`SwipeToReveal`:** fixes a ~1px coloured fringe of the action buttons showing around the
+  closed row (visibly over a host list's border). A composited descendant in the action slot
+  isn't clipped reliably by `overflow: hidden`, so the row now uses `contain: paint`, a hard
+  clip the compositor honours. Separately, the row no longer hard-codes `border-radius` (which
+  carved an arc out of every corner, mid-list rows included, that the panel showed through); it
+  inherits the host's rounding — square in a list that clips its own ends, rounded under a
+  rounded container, override with `class` / `ui.root`. The settled open offset also snaps to a
+  whole pixel so the panel edge lands crisp.
+
+## `SwipeToReveal` — edge is the slot you provide
+
+Actions now go in `#leading-actions` / `#trailing-actions`. Provide one for a single-edge row or
+both for a two-edge row — the drag's own direction picks which panel opens. `@change` reports the
+edge (`(open, side)`), `reveal(side?)` targets one, and `openSide` is exposed.
+
+The generic `#actions` slot and the `side` prop are gone — `side` only routed `#actions` to an
+edge with no behavioural effect. Migrate `#actions` → `#trailing-actions`, and `side="leading"` +
+`#actions` → `#leading-actions`.
+
+## `SwipeToReveal` — reveal progress + grow-in
+
+The 0 → 1 reveal progress for each edge is surfaced: as the `progress` slot prop on the actions
+slots, as `leadingProgress` / `trailingProgress` on the exposed instance, and as the
+`--ui-swipe-reveal-progress` custom property on each actions element — build your own
+gesture-driven effects off it.
+
+Built on that: the actions panel grows out of its own edge as the swipe reveals it, settling to
+full size (`--ui-ease-out`, `transform-origin` at the revealed edge). On by default; the new
+`revealScale` prop takes `false` to opt out (e.g. when driving the panel with your own timeline)
+or a number (0–1) for the closed-state scale, also tunable via `--ui-swipe-reveal-scale-from`.
+Respects `prefers-reduced-motion` and `motionCss={false}`.

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "gen": "node scripts/extract-component-meta.mjs && node scripts/generate-doc-demos.mjs",
-    "dev": "pnpm gen && vite --host",
+    "dev": "pnpm gen && vite",
     "build": "pnpm gen && vite-ssg build",
     "typecheck": "pnpm gen && vue-tsc --noEmit",
     "preview": "pnpm gen && vite preview"

--- a/docs/src/demos/Button/05-NotificationBadge.vue
+++ b/docs/src/demos/Button/05-NotificationBadge.vue
@@ -4,8 +4,9 @@
     <p class="note">
       Button owns the positioned wrapper (<code>badgePlacement</code>, default
       <code>top-end</code>); <code>Badge</code> stays the same context-free component it is
-      everywhere else. The wrapper only exists when a badge is actually rendered, so it costs
-      nothing on every other Button in this file.
+      everywhere else. The wrapper renders only when a badge is in play — a
+      <code>#badge</code> slot, or <code>badgePlacement</code> set to reserve the structure ahead of
+      a conditional badge — so it costs nothing on every other Button in this file.
     </p>
     <div class="row">
       <Button variant="secondary" icon aria-label="Notifications">

--- a/docs/src/demos/Button/06-BadgeInAFixedLayout.vue
+++ b/docs/src/demos/Button/06-BadgeInAFixedLayout.vue
@@ -1,0 +1,79 @@
+<template>
+  <section class="demo">
+    <h3>Badge in a fixed layout: reserve the wrapper with <code>badgePlacement</code></h3>
+    <p class="note">
+      A <code>#badge</code> slot that's <code>v-if</code>'d on real data (an unread count) would
+      otherwise flip the button between "plain element" and "wrapped in a span" the moment the first
+      badge appears — enough to knock a grid- or nth-child-placed button out of position. Setting
+      <code>badgePlacement</code> reserves the wrapper up front, and the button's own
+      <code>ui.root</code> class rides onto that wrapper, so its cell never moves.
+    </p>
+    <div class="pill">
+      <Button
+        v-for="tab in tabs"
+        :key="tab.id"
+        variant="ghost"
+        badge-placement="top-end"
+        :ui="{ root: { class: `pill-item pill-${tab.id}` } }"
+        :aria-label="tab.label"
+      >
+        <template v-if="tab.id === 'inbox' && unread > 0" #badge>
+          <Badge variant="danger" :count="unread" />
+        </template>
+        <component :is="tab.icon" weight="bold" />
+      </Button>
+    </div>
+    <div class="row">
+      <Button size="sm" variant="ghost" @click="unread++">+1 unread</Button>
+      <Button size="sm" variant="ghost" :disabled="unread === 0" @click="unread = 0">clear</Button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { shallowRef } from 'vue'
+import { Badge, Button } from 'vael-ui'
+import { PhHouse, PhTray, PhBell, PhGear } from '@phosphor-icons/vue'
+
+const unread = shallowRef(0)
+const tabs = [
+  { id: 'home', label: 'Home', icon: PhHouse },
+  { id: 'inbox', label: 'Inbox', icon: PhTray },
+  { id: 'activity', label: 'Activity', icon: PhBell },
+  { id: 'settings', label: 'Settings', icon: PhGear },
+]
+</script>
+
+<style scoped>
+.pill {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border: 1px solid var(--ui-border);
+  border-radius: 999px;
+  inline-size: fit-content;
+  margin-block-end: 1rem;
+}
+.pill-item {
+  justify-self: center;
+}
+/* Explicit cell placement — this is what silently broke when the wrapper
+   appeared and the button stopped being the grid's direct child. */
+.pill-home {
+  grid-column: 1;
+}
+.pill-inbox {
+  grid-column: 2;
+}
+.pill-activity {
+  grid-column: 3;
+}
+.pill-settings {
+  grid-column: 4;
+}
+.row {
+  display: flex;
+  gap: 0.5rem;
+}
+</style>

--- a/docs/src/demos/SwipeToReveal/01-Messages.vue
+++ b/docs/src/demos/SwipeToReveal/01-Messages.vue
@@ -8,7 +8,7 @@
           v-model:open="openState[message.id]"
           @change="(open) => onRowChange(message.id, open)"
         >
-          <template #actions="{ close }">
+          <template #trailing-actions="{ close }">
             <div class="swipe-actions">
               <Button variant="secondary" size="sm" @click="archive(message.id, close)">
                 Archive

--- a/docs/src/demos/SwipeToReveal/02-LeadingEdge.vue
+++ b/docs/src/demos/SwipeToReveal/02-LeadingEdge.vue
@@ -1,10 +1,10 @@
 <template>
   <section class="demo">
-    <h3>Reveal from the leading edge, <code>side="leading"</code></h3>
+    <h3>Reveal from the leading edge, <code>#leading-actions</code></h3>
     <ul class="swipe-list">
       <li class="swipe-row">
-        <SwipeToReveal side="leading">
-          <template #actions="{ close }">
+        <SwipeToReveal>
+          <template #leading-actions="{ close }">
             <div class="swipe-actions">
               <Button variant="primary" size="sm" @click="close">Mark read</Button>
             </div>

--- a/docs/src/demos/SwipeToReveal/03-BothEdges.vue
+++ b/docs/src/demos/SwipeToReveal/03-BothEdges.vue
@@ -1,0 +1,100 @@
+<template>
+  <section class="demo">
+    <h3>Both edges on one row: <code>#leading-actions</code> + <code>#trailing-actions</code></h3>
+    <p class="note">
+      One instance, two panels — the drag's own direction decides which one opens. Provide just one
+      slot to make it a single-edge row; omit both and the row is inert.
+    </p>
+    <ul class="swipe-list">
+      <li v-for="row in rows" :key="row.id" class="swipe-row">
+        <SwipeToReveal
+          v-model:open="openState[row.id]"
+          @change="
+            (open, side) => (lastChange = open ? `${row.from} · ${side}` : `${row.from} · closed`)
+          "
+        >
+          <template #leading-actions="{ close }">
+            <div class="swipe-actions">
+              <Button variant="primary" size="sm" @click="close">Pin</Button>
+            </div>
+          </template>
+          <template #trailing-actions="{ close }">
+            <div class="swipe-actions">
+              <Button variant="secondary" size="sm" @click="close">Archive</Button>
+              <Button variant="danger" size="sm" @click="close">Delete</Button>
+            </div>
+          </template>
+
+          <div class="swipe-content">
+            <Avatar :name="row.from" size="sm" />
+            <div class="swipe-body">
+              <strong>{{ row.from }}</strong>
+              <p class="note swipe-preview">{{ row.preview }}</p>
+            </div>
+          </div>
+        </SwipeToReveal>
+      </li>
+    </ul>
+    <p class="note">
+      Last change: <strong>{{ lastChange ?? 'none yet' }}</strong>
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, shallowRef } from 'vue'
+import { Avatar, Button, SwipeToReveal } from 'vael-ui'
+
+const rows = [
+  { id: 'a', from: 'Priya Nair', preview: 'Drag left for Archive / Delete, right to Pin.' },
+  { id: 'b', from: 'Marcus Lee', preview: 'Same row, either edge — your swipe direction picks.' },
+]
+const openState = reactive<Record<string, boolean>>({})
+const lastChange = shallowRef<string | null>(null)
+</script>
+
+<style scoped>
+.swipe-list {
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  max-inline-size: 28rem;
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius-surface);
+  overflow: hidden;
+}
+.swipe-row + .swipe-row {
+  border-block-start: 1px solid var(--ui-border);
+}
+.swipe-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--ui-surface);
+}
+.swipe-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-inline-size: 0;
+  flex: 1;
+}
+.swipe-preview {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.swipe-actions {
+  display: flex;
+  align-items: stretch;
+  gap: 1px;
+  block-size: 100%;
+  background: var(--ui-border);
+}
+.swipe-actions :deep(.ui-button) {
+  border-radius: 0;
+  inline-size: 5.5rem;
+}
+</style>

--- a/docs/src/demos/SwipeToReveal/04-ExtremeGSAPScrubbedActions.vue
+++ b/docs/src/demos/SwipeToReveal/04-ExtremeGSAPScrubbedActions.vue
@@ -1,0 +1,190 @@
+<template>
+  <section class="demo">
+    <h3>Extreme: gesture-scrubbed GSAP timeline for the actions (gsap)</h3>
+    <p class="note">
+      The panel's <code>progress</code> slot prop (0 → 1 as the edge is revealed) scrubs a paused
+      GSAP timeline, so the buttons cartwheel in <em>with</em> your finger and reverse when you drag
+      back. On release the library owns the settle — the timeline just eases to the same endpoint.
+      No internal classes touched; <code>:reveal-scale="false"</code> hands the panel to GSAP.
+    </p>
+    <ul class="swipe-list">
+      <li v-for="row in rows" :key="row.id" class="swipe-row">
+        <SwipeToReveal
+          :ref="(el) => setRowRef(row.id, el)"
+          v-model:open="openState[row.id]"
+          :reveal-scale="false"
+        >
+          <template #trailing-actions="{ close }">
+            <div class="gsap-actions">
+              <button
+                v-for="action in actions"
+                :key="action.label"
+                :ref="(el) => setActionRef(row.id, action.label, el as HTMLElement | null)"
+                type="button"
+                class="gsap-action"
+                :class="`gsap-action--${action.tone}`"
+                @click="close"
+              >
+                <component :is="action.icon" :size="18" weight="bold" />
+                <span>{{ action.label }}</span>
+              </button>
+            </div>
+          </template>
+
+          <div class="swipe-content">
+            <Avatar :name="row.from" size="sm" />
+            <div class="swipe-body">
+              <strong>{{ row.from }}</strong>
+              <p class="note swipe-preview">{{ row.preview }}</p>
+            </div>
+          </div>
+        </SwipeToReveal>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, reactive, watch } from 'vue'
+import { gsap } from 'gsap'
+import { Avatar, SwipeToReveal } from 'vael-ui'
+import { PhArchiveBox, PhPushPin, PhTrash } from '@phosphor-icons/vue'
+
+type SwipeInstance = InstanceType<typeof SwipeToReveal>
+
+const rows = [
+  { id: 'a', from: 'Priya Nair', preview: 'Swipe slowly — the buttons track the gesture.' },
+  { id: 'b', from: 'Marcus Lee', preview: 'Let go early and the timeline rewinds itself.' },
+]
+const actions = [
+  { label: 'Archive', tone: 'muted', icon: PhArchiveBox },
+  { label: 'Pin', tone: 'accent', icon: PhPushPin },
+  { label: 'Delete', tone: 'danger', icon: PhTrash },
+] as const
+
+const openState = reactive<Record<string, boolean>>({})
+const rowRefs = new Map<string, SwipeInstance>()
+const actionEls = new Map<string, HTMLElement[]>()
+const timelines = new Map<string, gsap.core.Timeline>()
+const stops: Array<() => void> = []
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+function setActionRef(rowId: string, label: string, el: HTMLElement | null) {
+  const list = actionEls.get(rowId) ?? []
+  const i = actions.findIndex((a) => a.label === label)
+  if (el) list[i] = el
+  actionEls.set(rowId, list)
+}
+
+function buildTimeline(rowId: string) {
+  const els = (actionEls.get(rowId) ?? []).filter(Boolean)
+  if (els.length === 0) return
+  const tl = gsap.timeline({ paused: true })
+  tl.from(els, {
+    xPercent: 120,
+    rotateZ: -35,
+    scale: 0.2,
+    opacity: 0,
+    transformOrigin: '50% 50%',
+    stagger: 0.14,
+    ease: 'back.out(2.2)',
+    duration: 1,
+  })
+  timelines.set(rowId, tl)
+}
+
+function setRowRef(rowId: string, el: unknown) {
+  const inst = (el as SwipeInstance | null) ?? null
+  if (!inst) {
+    rowRefs.delete(rowId)
+    return
+  }
+  if (rowRefs.has(rowId)) return
+  rowRefs.set(rowId, inst)
+
+  if (prefersReducedMotion()) return
+  buildTimeline(rowId)
+
+  const stop = watch(
+    () => [inst.trailingProgress, inst.isDragging] as const,
+    ([progress, dragging]) => {
+      const tl = timelines.get(rowId)
+      if (!tl) return
+      const p = Math.min(1, Math.max(0, progress))
+      if (dragging) tl.progress(p)
+      else gsap.to(tl, { progress: p, duration: 0.2, ease: 'power3.out', overwrite: true })
+    },
+    { flush: 'post' },
+  )
+  stops.push(stop)
+}
+
+onBeforeUnmount(() => {
+  stops.forEach((stop) => stop())
+  timelines.forEach((tl) => tl.kill())
+})
+</script>
+
+<style scoped>
+.swipe-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-inline-size: 28rem;
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius-surface);
+  overflow: hidden;
+}
+.swipe-row + .swipe-row {
+  border-block-start: 1px solid var(--ui-border);
+}
+.swipe-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--ui-surface);
+}
+.swipe-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-inline-size: 0;
+  flex: 1;
+}
+.swipe-preview {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gsap-actions {
+  display: flex;
+  block-size: 100%;
+}
+.gsap-action {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  inline-size: 5rem;
+  border: 0;
+  font: inherit;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+}
+.gsap-action--muted {
+  background: var(--ui-text-muted);
+}
+.gsap-action--accent {
+  background: var(--ui-info);
+}
+.gsap-action--danger {
+  background: var(--ui-danger);
+}
+</style>

--- a/packages/ui/src/components/Button/Button.css
+++ b/packages/ui/src/components/Button/Button.css
@@ -12,7 +12,6 @@
     cursor: pointer;
     user-select: none;
 
-    will-change: transform;
     transition:
       transform var(--ui-duration-press) var(--ui-ease-out),
       background-color var(--ui-duration-press) ease,

--- a/packages/ui/src/components/Button/Button.vue
+++ b/packages/ui/src/components/Button/Button.vue
@@ -1,5 +1,9 @@
 <template>
-  <span v-if="$slots.badge" class="ui-button-badge-wrapper">
+  <span
+    v-if="$slots.badge || badgePlacement !== undefined"
+    :class="['ui-button-badge-wrapper', wrapperRootPart.class]"
+    :style="wrapperRootPart.style"
+  >
     <component
       :is="as"
       ref="root"
@@ -40,7 +44,12 @@
         <slot name="trailing" />
       </span>
     </component>
-    <span :class="badgePart.class" :style="badgePart.style" :data-placement="badgePlacement">
+    <span
+      v-if="$slots.badge"
+      :class="badgePart.class"
+      :style="badgePart.style"
+      :data-placement="resolvedBadgePlacement"
+    >
       <slot name="badge" />
     </span>
   </span>
@@ -102,16 +111,20 @@ export type ButtonLoaderPlacement = 'overlay' | 'inline'
 
 <!--
   Loading: aria-disabled + click guard (preserves focus); loader stays mounted (interruptible crossfade).
-  Dual render paths: wrapper only with #badge (Vue scoped-style limitation — wrapper breaks :deep() for badge-less).
+  Dual render paths: the badge wrapper renders only with a badge in play (`#badge` slot, or
+  `badgePlacement` set to reserve the structure) so a plain button keeps its `:deep()`/sibling
+  selectors; when it IS the outer node it mirrors the consumer's own `ui.root`/class/style so
+  class-based placement still resolves. `defineExpose({ el })` is the inner button either way.
 -->
 <script setup lang="ts">
 import './Button.css'
 import '../shared/tokens.css'
 import '../shared/loader-spinner.css'
 import { computed, useAttrs, useSlots, useTemplateRef } from 'vue'
+import type { StyleValue } from 'vue'
 import { useAsyncLoading } from '../../composables/useAsyncLoading'
-import { useClassMerge, resolveUiPart } from '../../classes'
-import type { UiPartValue } from '../../classes'
+import { useClassMerge, resolveUiPart, splitUiPart } from '../../classes'
+import type { ClassValue, UiPartValue } from '../../classes'
 import { useThemedUi } from '../../theme'
 
 // Manual attrs binding intercepts onClick; rest still fall through.
@@ -137,7 +150,8 @@ const props = withDefaults(
     type?: 'button' | 'submit' | 'reset'
     /** Root tag (e.g. `as="a"` for a link styled as button). */
     as?: string
-    /** Where the `#badge` slot wrapper sits relative to the button. */
+    /** Where the `#badge` slot sits (default `top-end`). Setting it also reserves the wrapper up
+     * front, so a `v-if`'d `#badge` keeps a stable DOM position before the first badge appears. */
     badgePlacement?: 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end'
     ui?: Partial<{
       root: UiPartValue
@@ -163,7 +177,6 @@ const props = withDefaults(
     block: false,
     type: 'button',
     as: 'button',
-    badgePlacement: 'top-end',
   },
 )
 
@@ -259,6 +272,15 @@ const rootPart = computed(() =>
   ),
 )
 const badgePart = computed(() => resolveUiPart(cx, themedUi()?.badge, 'ui-button-badge'))
+const resolvedBadgePlacement = computed(() => props.badgePlacement ?? 'top-end')
+// The consumer's own root class/style, mirrored onto the wrapper when it's the outer node.
+const wrapperRootPart = computed(() => {
+  const uiRoot = splitUiPart(themedUi()?.root)
+  return {
+    class: cx(uiRoot.class, attrs.class as ClassValue),
+    style: [uiRoot.style, attrs.style] as StyleValue,
+  }
+})
 const leadingPart = computed(() => resolveUiPart(cx, themedUi()?.leading, 'ui-button-leading'))
 const trailingPart = computed(() => resolveUiPart(cx, themedUi()?.trailing, 'ui-button-trailing'))
 const contentPart = computed(() => resolveUiPart(cx, themedUi()?.content, 'ui-button-content'))

--- a/packages/ui/src/components/SwipeToReveal/SwipeToReveal.css
+++ b/packages/ui/src/components/SwipeToReveal/SwipeToReveal.css
@@ -1,8 +1,17 @@
 @layer ui-components {
   .ui-swipe-reveal {
     position: relative;
+    /* `contain: paint`, not just `overflow: hidden`: anything composited in the action slot
+       (a button with its own transform/filter, say) leaks ~1px past a plain overflow clip —
+       visibly over a host list's border. Paint containment is the hard clip the compositor
+       actually honours. */
+    contain: paint;
     overflow: hidden;
-    border-radius: var(--ui-radius);
+    /* Shape-agnostic: inherit the host's rounding rather than imposing our own. A list
+       clips its own ends, so every row must stay square — a hard-coded radius here carves
+       an arc out of every corner and the always-mounted action layer shows through it. A
+       standalone rounded host still passes its radius down. Consumers override via `class`. */
+    border-radius: inherit;
     touch-action: pan-y;
   }
   .ui-swipe-reveal-actions {
@@ -10,12 +19,40 @@
     inset-block: 0;
     display: flex;
     align-items: stretch;
+    /* When the host IS rounded, carve the panel's outer corners to match so it can't
+       paint a fringe into the corner behind the resting content. */
+    border-radius: inherit;
+    overflow: hidden;
   }
-  .ui-swipe-reveal[data-side='trailing'] .ui-swipe-reveal-actions {
+  .ui-swipe-reveal-actions[data-side='trailing'] {
     inset-inline-end: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
-  .ui-swipe-reveal[data-side='leading'] .ui-swipe-reveal-actions {
+  .ui-swipe-reveal-actions[data-side='leading'] {
     inset-inline-start: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+  /* Opt-in via the `revealScale` prop. The panel grows out of its own edge as the swipe
+     reveals it: --ui-swipe-reveal-progress runs 0 (closed) → 1 (open), set live off the drag
+     offset; --ui-swipe-reveal-scale-from is the closed-state scale, always settling to 1.
+     Progress is published on the actions elements regardless, for driving your own effects. */
+  .ui-swipe-reveal[data-reveal-scale] .ui-swipe-reveal-actions {
+    scale: calc(
+      var(--ui-swipe-reveal-scale-from, 0.94) + (1 - var(--ui-swipe-reveal-scale-from, 0.94)) *
+        var(--ui-swipe-reveal-progress, 1)
+    );
+    transition: scale var(--ui-duration-enter) var(--ui-ease-out);
+  }
+  .ui-swipe-reveal[data-reveal-scale] .ui-swipe-reveal-actions[data-side='trailing'] {
+    transform-origin: right center;
+  }
+  .ui-swipe-reveal[data-reveal-scale] .ui-swipe-reveal-actions[data-side='leading'] {
+    transform-origin: left center;
+  }
+  .ui-swipe-reveal[data-reveal-scale][data-dragging] .ui-swipe-reveal-actions {
+    transition: none;
   }
   .ui-swipe-reveal-content {
     position: relative;
@@ -32,9 +69,17 @@
   .ui-swipe-reveal[data-motion='off'] .ui-swipe-reveal-content {
     transition: none;
   }
+  .ui-swipe-reveal[data-reveal-scale][data-motion='off'] .ui-swipe-reveal-actions {
+    scale: 1;
+    transition: none;
+  }
 
   @media (prefers-reduced-motion: reduce) {
     .ui-swipe-reveal-content {
+      transition: none;
+    }
+    .ui-swipe-reveal[data-reveal-scale] .ui-swipe-reveal-actions {
+      scale: 1;
       transition: none;
     }
   }

--- a/packages/ui/src/components/SwipeToReveal/SwipeToReveal.vue
+++ b/packages/ui/src/components/SwipeToReveal/SwipeToReveal.vue
@@ -2,33 +2,60 @@
   <div
     ref="root"
     :class="rootPart.class"
-    :style="rootPart.style"
-    :data-side="side"
+    :style="[rootStyle, rootPart.style]"
+    :data-open-side="openSide || undefined"
     :data-dragging="isDragging || undefined"
     :data-motion="motionCss ? undefined : 'off'"
+    :data-reveal-scale="revealScaleOn || undefined"
     :aria-disabled="disabled || undefined"
     v-bind="attrs"
   >
-    <div ref="actionsEl" :class="actionsPart.class" :style="actionsPart.style">
-      <slot name="actions" :open="open" :close="close" />
+    <div
+      v-if="hasLeading"
+      ref="leadingActionsEl"
+      :class="actionsPart.class"
+      :style="[{ '--ui-swipe-reveal-progress': leadingProgress }, actionsPart.style]"
+      data-side="leading"
+    >
+      <slot
+        name="leading-actions"
+        :open="openSide === 'leading'"
+        :close="close"
+        :progress="leadingProgress"
+      />
+    </div>
+    <div
+      v-if="hasTrailing"
+      ref="trailingActionsEl"
+      :class="actionsPart.class"
+      :style="[{ '--ui-swipe-reveal-progress': trailingProgress }, actionsPart.style]"
+      data-side="trailing"
+    >
+      <slot
+        name="trailing-actions"
+        :open="openSide === 'trailing'"
+        :close="close"
+        :progress="trailingProgress"
+      />
     </div>
     <div
       ref="contentEl"
       :class="contentPart.class"
-      :style="[{ transform: `translateX(${signedOffset}px)` }, contentPart.style]"
+      :style="[{ transform: `translateX(${offset}px)` }, contentPart.style]"
       @pointerdown="onContentPointerdown"
       @click.capture="onContentClick"
     >
-      <slot :open="open" :reveal="reveal" :close="close" />
+      <slot :open="open" :open-side="openSide" :reveal="reveal" :close="close" />
     </div>
   </div>
 </template>
 
-<!-- Swipe-to-reveal primitive with ONE side at a time; actions always in DOM for a11y; tap-to-close uses capture phase. -->
+<!-- Swipe-to-reveal primitive. Either or both edges (#leading-actions / #trailing-actions, drag
+     direction picks); actions stay in the DOM for a11y; tap-to-close is capture-phase. -->
 <script setup lang="ts">
 import './SwipeToReveal.css'
 import '../shared/tokens.css'
-import { computed, useAttrs, useTemplateRef } from 'vue'
+import { computed, useAttrs, useSlots, useTemplateRef } from 'vue'
 import { useElementSize } from '@vueuse/core'
 import { useSwipeReveal } from '../../composables/useSwipeReveal'
 import type { SwipeRevealSide } from '../../composables/useSwipeReveal'
@@ -39,54 +66,88 @@ import { useThemedUi } from '../../theme'
 defineOptions({ inheritAttrs: false })
 
 const attrs = useAttrs()
+const slots = useSlots()
 const open = defineModel<boolean>('open', { default: false })
 
 const props = withDefaults(
   defineProps<{
-    side?: SwipeRevealSide
     disabled?: boolean
     /** `false` disables the built-in release/settle transition entirely (via `data-motion="off"`)
      * — reach for this if you're driving the settle with your own spring/GSAP timeline instead.
      * Has no effect on the drag itself, which is already transform-only with no transition. */
     motionCss?: boolean
+    /** Grow the actions panel in from its own edge as the swipe reveals it, settling to full
+     * size. On by default; `false` opts out (e.g. when driving the panel with your own
+     * timeline), a number (0–1) sets the closed-state scale. The raw 0→1 reveal progress is
+     * always on the `progress` slot prop and the `--ui-swipe-reveal-progress` custom property
+     * for driving your own effects. */
+    revealScale?: boolean | number
     ui?: Partial<{ root: UiPartValue; content: UiPartValue; actions: UiPartValue }>
   }>(),
   {
-    side: 'trailing',
     disabled: false,
     motionCss: true,
+    revealScale: true,
     ui: undefined,
   },
 )
 
 const emit = defineEmits<{
-  change: [open: boolean]
+  /** Once per settled interaction: `open`, and which edge (or `null`). */
+  change: [open: boolean, side: SwipeRevealSide | null]
 }>()
 
+// Every actions slot stays mounted (visually clipped) so its buttons are always keyboard-reachable.
 defineSlots<{
-  default(props: { open: boolean; reveal: () => void; close: () => void }): unknown
-  // Always in the DOM for accessibility
-  actions(props: { open: boolean; close: () => void }): unknown
+  default(props: {
+    open: boolean
+    openSide: SwipeRevealSide | null
+    reveal: (side?: SwipeRevealSide) => void
+    close: () => void
+  }): unknown
+  /** Leading-edge (left, LTR) actions. `progress` is 0 → 1 as this edge is revealed. */
+  'leading-actions'(props: { open: boolean; close: () => void; progress: number }): unknown
+  /** Trailing-edge (right, LTR) actions. `progress` is 0 → 1 as this edge is revealed. */
+  'trailing-actions'(props: { open: boolean; close: () => void; progress: number }): unknown
 }>()
+
+const hasLeading = computed(() => !!slots['leading-actions'])
+const hasTrailing = computed(() => !!slots['trailing-actions'])
 
 const root = useTemplateRef<HTMLElement>('root')
 const contentEl = useTemplateRef<HTMLElement>('contentEl')
-const actionsEl = useTemplateRef<HTMLElement>('actionsEl')
+const leadingActionsEl = useTemplateRef<HTMLElement>('leadingActionsEl')
+const trailingActionsEl = useTemplateRef<HTMLElement>('trailingActionsEl')
 
-const { width: actionsWidth } = useElementSize(actionsEl)
+const { width: leadingWidth } = useElementSize(leadingActionsEl)
+const { width: trailingWidth } = useElementSize(trailingActionsEl)
 
-const { isDragging, offset, onContentPointerdown, onContentClick, reveal, close } = useSwipeReveal(
-  open,
-  {
-    side: () => props.side,
-    actionsWidth,
+const { isDragging, offset, openSide, onContentPointerdown, onContentClick, reveal, close } =
+  useSwipeReveal(open, {
+    leading: () => hasLeading.value,
+    trailing: () => hasTrailing.value,
+    leadingWidth,
+    trailingWidth,
     disabled: () => props.disabled,
-    onCommit: (value) => emit('change', value),
-  },
+    onCommit: (side) => emit('change', side !== null, side),
+  })
+
+// 0 → 1: how far the drag/settle has revealed each edge. Exposed for consumer-driven effects;
+// also drives the opt-in `revealScale` grow-in.
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n))
+const leadingProgress = computed(() =>
+  leadingWidth.value > 0 ? clamp01(offset.value / leadingWidth.value) : 0,
+)
+const trailingProgress = computed(() =>
+  trailingWidth.value > 0 ? clamp01(-offset.value / trailingWidth.value) : 0,
 )
 
-// Signed offset: trailing actions pull left (negative), leading pulls right
-const signedOffset = computed(() => (props.side === 'trailing' ? -offset.value : offset.value))
+const revealScaleOn = computed(() => props.revealScale !== false)
+const rootStyle = computed(() =>
+  typeof props.revealScale === 'number'
+    ? { '--ui-swipe-reveal-scale-from': String(props.revealScale) }
+    : undefined,
+)
 
 const cx = useClassMerge()
 const themedUi = useThemedUi(
@@ -108,5 +169,17 @@ const actionsPart = computed(() =>
   resolveUiPart(cx, themedUi()?.actions, 'ui-swipe-reveal-actions'),
 )
 
-defineExpose({ el: root, contentEl, actionsEl, isDragging, reveal, close })
+defineExpose({
+  el: root,
+  contentEl,
+  leadingActionsEl,
+  trailingActionsEl,
+  isDragging,
+  openSide,
+  /** 0 → 1 reveal progress for each edge — live during a drag, settled after. */
+  leadingProgress,
+  trailingProgress,
+  reveal,
+  close,
+})
 </script>

--- a/packages/ui/src/composables/useSheetDrag.ts
+++ b/packages/ui/src/composables/useSheetDrag.ts
@@ -14,7 +14,7 @@ export interface UseSheetDragOptions {
   panelEl: ElRef<HTMLElement | null>
   /** Pointer-down here always starts a drag. */
   handleEl: ElRef<HTMLElement | null>
-  /** Pointer-down here only starts a drag once its own scroll is at the top and the drag moves downward — otherwise it's an ordinary scroll. */
+  /** Pointer-down here only starts a drag once its own scroll is at the top, the drag is vertically dominant, and it moves downward — otherwise it's an ordinary scroll (or a horizontal gesture that belongs to something nested, like a swipe-to-reveal row). */
   contentEl?: ElRef<HTMLElement | null>
   /** Ordered smallest to largest. */
   snapPoints: MaybeRefOrGetter<SheetSnapPoint[]>
@@ -41,6 +41,7 @@ const FAST_VELOCITY = 2 // px/ms — a real flick, matches Vaul's jump-to-extrem
 const VELOCITY_THRESHOLD = 0.4 // px/ms — matches Vaul's "was this deliberate" gate
 const SHORT_DRAG_FRACTION = 0.4 // of viewport height — Vaul's step-one-snap-point vs settle-to-nearest split
 const NESTED_DISPLACEMENT = 16 // px — Vaul's own recede distance for stacked sheets
+const AXIS_LOCK_THRESHOLD = 8 // px — movement before a content drag commits to an axis; matches useSwipeReveal
 // Shifted-log curve (Vaul); viewport-scale range.
 const RUBBER_BAND_DAMPEN = 60
 
@@ -131,6 +132,7 @@ export function useSheetDrag(
   })
 
   let dragSource: 'handle' | 'content' | null = null
+  let dragStartX = 0
   let dragStartY = 0
   let dragStartOffset = 0
   let dragStartTime = 0
@@ -155,6 +157,7 @@ export function useSheetDrag(
 
   function onContentPointerDown(event: PointerEvent) {
     dragSource = 'content'
+    dragStartX = event.clientX
     dragStartY = event.clientY
     dragStartScrollTop = options.contentEl?.value?.scrollTop ?? 0
   }
@@ -162,7 +165,15 @@ export function useSheetDrag(
   function onPointerMove(event: PointerEvent) {
     if (!dragSource) return
     if (dragSource === 'content') {
-      const draggingDown = event.clientY > dragStartY
+      const dx = event.clientX - dragStartX
+      const dy = event.clientY - dragStartY
+      if (Math.abs(dx) < AXIS_LOCK_THRESHOLD && Math.abs(dy) < AXIS_LOCK_THRESHOLD) return
+      // Horizontally-dominant → belongs to something nested (a swipe-to-reveal row), not a dismiss.
+      if (Math.abs(dx) >= Math.abs(dy)) {
+        dragSource = null
+        return
+      }
+      const draggingDown = dy > 0
       const atTop = dragStartScrollTop === 0
       if (!(atTop && draggingDown)) return
       dragSource = 'handle'

--- a/packages/ui/src/composables/useSwipeReveal.ts
+++ b/packages/ui/src/composables/useSwipeReveal.ts
@@ -15,25 +15,30 @@ export interface SwipeCommitInput {
 }
 
 export interface UseSwipeRevealOptions {
-  side?: MaybeRefOrGetter<SwipeRevealSide>
-  /** Width (px) of the actions panel — the fully-open extreme. A getter since it's measured off a real element that can change size (responsive action labels, …) — SwipeToReveal.vue feeds this from `useElementSize`. */
-  actionsWidth: MaybeRefOrGetter<number>
+  /** Whether a leading / trailing actions panel exists to reveal toward. */
+  leading?: MaybeRefOrGetter<boolean>
+  trailing?: MaybeRefOrGetter<boolean>
+  /** Px width of each actions panel — its fully-open extreme. Getters; measured off real elements. */
+  leadingWidth: MaybeRefOrGetter<number>
+  trailingWidth: MaybeRefOrGetter<number>
   disabled?: MaybeRefOrGetter<boolean>
-  /** Fires once per settled interaction (pointer release, or a programmatic
-   * reveal()/close()) — mirrors useResizable's own onCommit. */
-  onCommit?: (open: boolean) => void
+  /** Fires once per settled interaction with the edge that ended up open, or `null` for closed. */
+  onCommit?: (openSide: SwipeRevealSide | null) => void
 }
 
 export interface UseSwipeRevealReturn {
   /** True for the entire span of a COMMITTED drag (past DRAG_THRESHOLD) —
    * never set for a plain tap, matching useResizable's isDragging shape. */
   isDragging: Ref<boolean>
-  /** Live px offset toward the open side — 0 = closed, `actionsWidth` = fully open, past either end while rubber-banding. Bind directly to `transform: translateX()` on the content element (signed by `side`) — never through a CSS custom property + calc(), same direct-write convention as useResizable's own model. */
+  /** Live SIGNED px offset for `transform: translateX()`: `>0` leading edge revealed, `<0` trailing, `0` closed. */
   offset: Ref<number>
+  /** The revealed (or settling-toward) edge, or `null` when closed. */
+  openSide: Ref<SwipeRevealSide | null>
   onContentPointerdown: (event: PointerEvent) => void
-  /** Intercepts a tap on the content while open: closes instead of letting the row's own click fire, and swallows the browser's own trailing click that follows a completed drag (see the comment on `suppressNextClick` below) so a drag-to-open never immediately re-closes itself. */
+  /** Intercepts a tap on the content while open: closes instead of letting the row's own click fire, and swallows the browser's own trailing click that follows a completed drag so a drag-to-open never immediately re-closes itself. */
   onContentClick: (event: MouseEvent) => void
-  reveal: () => void
+  /** Open a specific edge. With one panel the argument is optional; with both, defaults to `trailing`. */
+  reveal: (side?: SwipeRevealSide) => void
   close: () => void
 }
 
@@ -69,38 +74,71 @@ export function useSwipeReveal(
 ): UseSwipeRevealReturn {
   const isDragging = shallowRef(false)
 
-  function actionsWidth(): number {
-    return Math.max(0, toValue(options.actionsWidth))
+  function leadingActive(): boolean {
+    return toValue(options.leading) ?? false
   }
-  function side(): SwipeRevealSide {
-    return toValue(options.side) ?? 'trailing'
+  function trailingActive(): boolean {
+    return toValue(options.trailing) ?? true
+  }
+  function leadingWidth(): number {
+    return leadingActive() ? Math.max(0, toValue(options.leadingWidth)) : 0
+  }
+  function trailingWidth(): number {
+    return trailingActive() ? Math.max(0, toValue(options.trailingWidth)) : 0
   }
   function isDisabled(): boolean {
     return toValue(options.disabled) ?? false
   }
+  /** The edge a bare `reveal()` / an externally-set `open = true` targets. */
+  function defaultSide(): SwipeRevealSide {
+    return leadingActive() && !trailingActive() ? 'leading' : 'trailing'
+  }
+  // Settled offset only (initial value, v-model sync, reveal, release). Rounded so the
+  // content edge lands on a whole pixel flush with the actions panel — measured widths
+  // are fractional (useElementSize), and a subpixel gap shows as a ~1px seam at rest.
+  // Live drag never routes through here; it stays fractional via rubberBand().
+  function offsetFor(side: SwipeRevealSide | null): number {
+    if (side === 'leading') return Math.round(leadingWidth())
+    if (side === 'trailing') return -Math.round(trailingWidth())
+    return 0
+  }
 
-  const offset = shallowRef(open.value ? actionsWidth() : 0)
+  const openSide = shallowRef<SwipeRevealSide | null>(open.value ? defaultSide() : null)
+  const offset = shallowRef(offsetFor(openSide.value))
 
   function rubberBand(value: number): number {
-    const hi = actionsWidth()
+    const hi = leadingWidth()
+    const lo = -trailingWidth()
     if (value > hi) return hi + dampen(value - hi)
-    if (value < 0) return -dampen(-value)
+    if (value < lo) return lo - dampen(lo - value)
     return value
   }
 
-  // Keep live offset synced with v-model/reveal/close and panel resize.
-  watch([open, () => actionsWidth()], () => {
+  // Keep the live offset synced with v-model/reveal/close and panel resize.
+  watch([open, () => leadingWidth(), () => trailingWidth()], () => {
     if (isDragging.value) return
-    offset.value = open.value ? actionsWidth() : 0
+    if (open.value) {
+      if (!openSide.value) openSide.value = defaultSide()
+      offset.value = offsetFor(openSide.value)
+    } else {
+      openSide.value = null
+      offset.value = 0
+    }
   })
 
-  function reveal() {
+  function reveal(side?: SwipeRevealSide) {
+    const target = side ?? defaultSide()
+    if (target === 'leading' ? !leadingActive() : !trailingActive()) return
+    openSide.value = target
     open.value = true
-    options.onCommit?.(true)
+    offset.value = offsetFor(target)
+    options.onCommit?.(target)
   }
   function close() {
+    openSide.value = null
     open.value = false
-    options.onCommit?.(false)
+    offset.value = 0
+    options.onCommit?.(null)
   }
 
   let pointerId: number | null = null
@@ -142,8 +180,7 @@ export function useSwipeReveal(
       dragEl?.setPointerCapture(pointerId)
     }
     event.preventDefault()
-    const signedOpening = side() === 'trailing' ? -dx : dx
-    liveOffset = rubberBand(startOffset + signedOpening)
+    liveOffset = rubberBand(startOffset + dx)
     offset.value = liveOffset
   }
 
@@ -154,26 +191,29 @@ export function useSwipeReveal(
     committed = false
     isDragging.value = false
     // Not a committed drag — a plain tap, or an abandoned vertical scroll.
-    // Nothing to settle; the native click (if any) proceeds untouched.
     if (!wasCommitted) return
 
     suppressNextClick = true
     const dx = event.clientX - startX
-    const signedOpening = side() === 'trailing' ? -dx : dx
+    // Edge this drag worked toward — offset sign at release, or the drag direction if it's at rest.
+    const side: SwipeRevealSide =
+      liveOffset > 0 || (liveOffset === 0 && dx > 0) ? 'leading' : 'trailing'
+    const width = side === 'leading' ? leadingWidth() : trailingWidth()
+    const signedOpening = side === 'leading' ? dx : -dx
     const elapsed = Math.max(1, performance.now() - startTime)
     const velocity = Math.abs(signedOpening) / elapsed
-    const width = actionsWidth()
     const shouldOpen =
       width <= 0
         ? false
         : resolveSwipeCommit({
             velocity,
             towardOpen: signedOpening > 0,
-            openFraction: liveOffset / width,
+            openFraction: Math.abs(liveOffset) / width,
           })
-    offset.value = shouldOpen ? width : 0
+    openSide.value = shouldOpen ? side : null
     open.value = shouldOpen
-    options.onCommit?.(shouldOpen)
+    offset.value = shouldOpen ? offsetFor(side) : 0
+    options.onCommit?.(openSide.value)
   }
 
   useEventListener(ssrWindow, 'pointermove', onPointerMove)
@@ -194,5 +234,5 @@ export function useSwipeReveal(
     close()
   }
 
-  return { isDragging, offset, onContentPointerdown, onContentClick, reveal, close }
+  return { isDragging, offset, openSide, onContentPointerdown, onContentClick, reveal, close }
 }

--- a/packages/ui/tests/bottom-sheet.test.ts
+++ b/packages/ui/tests/bottom-sheet.test.ts
@@ -163,3 +163,62 @@ test('custom beforeClose overrides the built-in exit for every close path, inclu
   captured[0]()
   await expect.element(screen.getByTestId('open-state')).toHaveTextContent('closed')
 })
+
+test('a horizontally-dominant drag on content at the top is left for a nested gesture, not hijacked into a dismiss', async () => {
+  const screen = render(BottomSheetFixture)
+  await screen.getByTestId('trigger').click()
+  await vi.waitFor(() => expect(visibleHeight()).toBeCloseTo(window.innerHeight * 0.6, -1))
+
+  content().scrollTop = 0
+  const restingHeight = visibleHeight()
+
+  // Mostly sideways with a few px of downward drift — the shape of a real
+  // swipe-to-reveal gesture that used to satisfy "moved down at all" and steal
+  // the pointer for a sheet dismiss.
+  const c = content()
+  const pointerId = 7
+  c.dispatchEvent(
+    new PointerEvent('pointerdown', { clientX: 60, clientY: 320, pointerId, bubbles: true }),
+  )
+  await new Promise((r) => setTimeout(r, 30))
+  c.dispatchEvent(
+    new PointerEvent('pointermove', { clientX: 130, clientY: 326, pointerId, bubbles: true }),
+  )
+  c.dispatchEvent(
+    new PointerEvent('pointermove', { clientX: 200, clientY: 330, pointerId, bubbles: true }),
+  )
+  c.dispatchEvent(
+    new PointerEvent('pointerup', { clientX: 200, clientY: 330, pointerId, bubbles: true }),
+  )
+
+  expect(Math.abs(visibleHeight() - restingHeight)).toBeLessThan(10)
+  await expect.element(screen.getByTestId('open-state')).toHaveTextContent('open')
+})
+
+test('a vertically-dominant downward drag on content at the top still promotes to a sheet dismiss', async () => {
+  const screen = render(BottomSheetFixture)
+  await screen.getByTestId('trigger').click()
+  await vi.waitFor(() => expect(visibleHeight()).toBeCloseTo(window.innerHeight * 0.6, -1))
+
+  content().scrollTop = 0
+
+  // Straight down, quick: the first move promotes the content drag to a sheet
+  // drag, the rest carry it into a flick-dismiss.
+  const c = content()
+  const pointerId = 8
+  c.dispatchEvent(
+    new PointerEvent('pointerdown', { clientX: 100, clientY: 200, pointerId, bubbles: true }),
+  )
+  await new Promise((r) => setTimeout(r, 20))
+  c.dispatchEvent(
+    new PointerEvent('pointermove', { clientX: 102, clientY: 216, pointerId, bubbles: true }),
+  )
+  c.dispatchEvent(
+    new PointerEvent('pointermove', { clientX: 103, clientY: 320, pointerId, bubbles: true }),
+  )
+  c.dispatchEvent(
+    new PointerEvent('pointerup', { clientX: 103, clientY: 320, pointerId, bubbles: true }),
+  )
+
+  await expect.element(screen.getByTestId('open-state')).toHaveTextContent('closed')
+})

--- a/packages/ui/tests/button-badge.test.ts
+++ b/packages/ui/tests/button-badge.test.ts
@@ -79,3 +79,37 @@ test('block + badge together: wrapper stretches to full width, badge still corne
 
   await expect.element(badge()!).toHaveAttribute('data-placement', 'top-end')
 })
+
+// A conditionally-rendered `#badge` slot (`v-if` on an unread count, say) used to
+// flip the whole button between "wrapper" and "no wrapper" structure the instant
+// the first badge appeared — throwing off any parent CSS that had grid-placed /
+// nth-child-targeted the button. Setting `badgePlacement` now reserves the wrapper
+// up front so the structure is stable, and the consumer's own root class rides
+// onto the wrapper (the real outer element) either way.
+
+test('badgePlacement set with no badge yet: the wrapper still renders, so the structure is stable', async () => {
+  render(Button, { props: { badgePlacement: 'top-end' }, slots: { default: 'Inbox' } })
+  expect(document.querySelector('.ui-button-badge-wrapper')).not.toBeNull()
+  expect(wrapper().querySelector('.ui-button')?.tagName).toBe('BUTTON')
+  expect(badge()).toBeNull() // no badge content, just the reserved structure
+})
+
+test("the consumer's ui.root class lands on the wrapper when the wrapper is the outer element", async () => {
+  render(Button, {
+    props: { badgePlacement: 'top-end', ui: { root: { class: 'grid-placed' } } },
+    slots: { default: 'Inbox', badge: '<span>3</span>' },
+  })
+  // The wrapper is what a parent grid sees as its child — the placement class
+  // has to be on it, not only on the inner button.
+  expect(wrapper().classList.contains('grid-placed')).toBe(true)
+  expect(document.querySelector('.ui-button')?.classList.contains('grid-placed')).toBe(true)
+})
+
+test('a plain class fallthrough also rides onto the wrapper', async () => {
+  render(Button, {
+    attrs: { class: 'nav-item' },
+    props: { badgePlacement: 'top-end' },
+    slots: { default: 'Inbox', badge: '<span>3</span>' },
+  })
+  expect(wrapper().classList.contains('nav-item')).toBe(true)
+})

--- a/packages/ui/tests/fixtures/SwipeToRevealFixture.vue
+++ b/packages/ui/tests/fixtures/SwipeToRevealFixture.vue
@@ -3,20 +3,27 @@
     ref="swipeRef"
     data-testid="row"
     v-model:open="open"
-    :side="side"
     :disabled="disabled"
     @change="onChange"
   >
-    <template #actions="{ close: closeActions }">
+    <template v-if="dual || side === 'leading'" #leading-actions="{ close: closeActions }">
+      <button type="button" data-testid="pin" @click="closeActions">Pin</button>
+    </template>
+    <template v-if="dual || side === 'trailing'" #trailing-actions="{ close: closeActions }">
       <button type="button" data-testid="archive" @click="closeActions">Archive</button>
       <button type="button" data-testid="delete">Delete</button>
     </template>
     <div data-testid="content" @click="onContentClick">Row content</div>
   </SwipeToReveal>
   <output data-testid="open-state">{{ open ? 'open' : 'closed' }}</output>
+  <output data-testid="open-side">{{ swipeRef?.openSide ?? 'none' }}</output>
   <output data-testid="change-count">{{ changeCount }}</output>
+  <output data-testid="last-change-side">{{ lastChangeSide }}</output>
   <output data-testid="content-click-count">{{ contentClickCount }}</output>
-  <button type="button" data-testid="reveal-btn" @click="revealRef?.reveal()">Reveal</button>
+  <button type="button" data-testid="reveal-btn" @click="swipeRef?.reveal()">Reveal</button>
+  <button type="button" data-testid="reveal-leading-btn" @click="swipeRef?.reveal('leading')">
+    Reveal leading
+  </button>
 
   <button data-testid="before">Before</button>
 </template>
@@ -26,21 +33,24 @@ import { shallowRef, useTemplateRef } from 'vue'
 import SwipeToReveal from '../../src/components/SwipeToReveal/SwipeToReveal.vue'
 import type { SwipeRevealSide } from '../../src/composables/useSwipeReveal'
 
-withDefaults(defineProps<{ side?: SwipeRevealSide; disabled?: boolean }>(), {
+withDefaults(defineProps<{ side?: SwipeRevealSide; disabled?: boolean; dual?: boolean }>(), {
   side: 'trailing',
   disabled: false,
+  dual: false,
 })
 
 const open = shallowRef(false)
 const changeCount = shallowRef(0)
+const lastChangeSide = shallowRef('none')
 const contentClickCount = shallowRef(0)
-function onChange() {
+function onChange(_open: boolean, revealedSide: SwipeRevealSide | null) {
   changeCount.value += 1
+  lastChangeSide.value = revealedSide ?? 'none'
 }
 function onContentClick() {
   contentClickCount.value += 1
 }
 
-const revealRef = useTemplateRef<InstanceType<typeof SwipeToReveal>>('swipeRef')
+const swipeRef = useTemplateRef<InstanceType<typeof SwipeToReveal>>('swipeRef')
 defineExpose({ open })
 </script>

--- a/packages/ui/tests/swipe-to-reveal.test.ts
+++ b/packages/ui/tests/swipe-to-reveal.test.ts
@@ -32,7 +32,7 @@ test('motionCss=false sets data-motion="off" and disables the settle transition'
     await import('../src/components/SwipeToReveal/SwipeToReveal.vue')
   const screen = render(SwipeToReveal, {
     props: { motionCss: false },
-    slots: { default: 'Content', actions: 'Delete' },
+    slots: { default: 'Content', 'trailing-actions': 'Delete' },
   })
   const root = screen.container.querySelector<HTMLElement>('.ui-swipe-reveal')!
   const content = screen.container.querySelector<HTMLElement>('.ui-swipe-reveal-content')!
@@ -172,4 +172,54 @@ test('side="leading" reveals from the left — a rightward drag opens it', async
   pointerup(rect.left + 80, rect.top + 10)
 
   await expect.element(screen.getByTestId('open-state')).toHaveTextContent('open')
+})
+
+// ---------------------------------------------------------------------------
+// Both edges on one instance: #leading-actions + #trailing-actions, the drag
+// direction picks which panel opens.
+// ---------------------------------------------------------------------------
+
+test('dual edges: a leftward drag opens the trailing panel', async () => {
+  const screen = render(SwipeToRevealFixture, { props: { dual: true } })
+  const content = testId(screen, 'content')
+  const rect = content.getBoundingClientRect()
+
+  pointerdown(content, rect.right - 5, rect.top + 10)
+  pointermove(rect.right - 15, rect.top + 10)
+  pointermove(rect.right - 80, rect.top + 10)
+  pointerup(rect.right - 80, rect.top + 10)
+
+  await expect.element(screen.getByTestId('open-state')).toHaveTextContent('open')
+  await expect.element(screen.getByTestId('open-side')).toHaveTextContent('trailing')
+  await expect.element(screen.getByTestId('last-change-side')).toHaveTextContent('trailing')
+})
+
+test('dual edges: a rightward drag opens the leading panel', async () => {
+  const screen = render(SwipeToRevealFixture, { props: { dual: true } })
+  const content = testId(screen, 'content')
+  const rect = content.getBoundingClientRect()
+
+  pointerdown(content, rect.left + 5, rect.top + 10)
+  pointermove(rect.left + 15, rect.top + 10)
+  pointermove(rect.left + 80, rect.top + 10)
+  pointerup(rect.left + 80, rect.top + 10)
+
+  await expect.element(screen.getByTestId('open-state')).toHaveTextContent('open')
+  await expect.element(screen.getByTestId('open-side')).toHaveTextContent('leading')
+  await expect.element(screen.getByTestId('last-change-side')).toHaveTextContent('leading')
+})
+
+test('dual edges: reveal(side) opens the named panel without a drag', async () => {
+  const screen = render(SwipeToRevealFixture, { props: { dual: true } })
+  await userEvent.click(testId(screen, 'reveal-leading-btn'))
+  await expect.element(screen.getByTestId('open-state')).toHaveTextContent('open')
+  await expect.element(screen.getByTestId('open-side')).toHaveTextContent('leading')
+})
+
+test('dual edges: both action panels are in the DOM from the start (accessibility)', async () => {
+  const screen = render(SwipeToRevealFixture, { props: { dual: true } })
+  expect(testId(screen, 'pin')).not.toBeNull()
+  expect(testId(screen, 'archive')).not.toBeNull()
+  expect(testId(screen, 'delete')).not.toBeNull()
+  expect(screen.container.querySelectorAll('.ui-swipe-reveal-actions').length).toBe(2)
 })

--- a/packages/vapor-ui/tests/fixtures/SmokeTestRoot.vue
+++ b/packages/vapor-ui/tests/fixtures/SmokeTestRoot.vue
@@ -100,7 +100,7 @@
     <h2>Gestures</h2>
     <div class="demo-row" data-testid="smoke-SwipeToReveal">
       <SwipeToReveal>
-        <template #actions>Delete</template>
+        <template #trailing-actions>Delete</template>
         <template #default>Content</template>
       </SwipeToReveal>
     </div>

--- a/playground/vapor/src/App.vue
+++ b/playground/vapor/src/App.vue
@@ -100,7 +100,7 @@
     <h2>Gestures</h2>
     <div class="demo-row" data-testid="smoke-SwipeToReveal">
       <SwipeToReveal>
-        <template #actions>Delete</template>
+        <template #trailing-actions>Delete</template>
         <template #default>Content</template>
       </SwipeToReveal>
     </div>


### PR DESCRIPTION
## 0.3.4 patch

Dogfooding: `SwipeToReveal` corner rendering, a slot API cleanup, and a reveal-progress hook. Changeset: patch.

### Fixes

- **SwipeToReveal:** removed the ~1px coloured fringe of the action buttons around a closed row (visible over a host list's border).
  - `contain: paint` on the row — a composited descendant in the action slot (`.ui-button` had `will-change: transform`) isn't clipped reliably by `overflow: hidden`.
  - Row no longer hard-codes `border-radius` — it inherits the host's, so mid-list rows stay square and the ends are the list's to round. Override with `class` / `ui.root`.
  - Settled open offset snaps to a whole pixel; the live drag stays fractional.
- **Button:** dropped the always-on `will-change: transform` — it forced a permanent compositor layer per button and leaked edges past clipping ancestors. The `:active` press-scale still animates.
- **Button:** a `v-if`'d `#badge` slot no longer shifts a grid- / `nth-child`-placed button when the first badge appears — the wrapper is reserved up front, and `ui.root` / `class` / `style` ride onto it.
- **BottomSheet:** a horizontal drag starting inside scrollable content (a `SwipeToReveal` row) is no longer hijacked into pull-to-dismiss on a few px of vertical drift — `useSheetDrag` runs the same axis-dominance check `SwipeToReveal` does.

### SwipeToReveal — API

- Actions live in `#leading-actions` / `#trailing-actions` only. One slot = single-edge row; both = drag direction picks.
- **Removed:** the `#actions` slot and the `side` prop (`side` only routed `#actions` to an edge, no behaviour). Migrate `#actions` -> `#trailing-actions`, `side="leading"` + `#actions` -> `#leading-actions`.
- `@change` reports `(open, side)`; `reveal(side?)` targets one edge; `openSide` exposed.

### SwipeToReveal — reveal progress + grow-in

- `0 -> 1` reveal progress per edge, exposed three ways: `progress` slot prop, `leadingProgress` / `trailingProgress` on the instance, `--ui-swipe-reveal-progress` custom property on the actions element.
- Built-in grow-in: the actions panel scales from its own edge as the swipe reveals it, settling to full size (`0.94 -> 1`, `transform-origin` at the revealed edge, 200ms `--ui-ease-out`).
- **On by default.** `:reveal-scale="false"` opts out; a number (0-1) sets the closed-state scale; `--ui-swipe-reveal-scale-from` tunes it in CSS.
- Off under `prefers-reduced-motion` and `motionCss={false}`.

### Docs

- New extreme demo: a paused GSAP timeline scrubbed by the reveal `progress` — buttons cartwheel in with the finger, rewind on drag-back, ease to endpoint on release.
- Migrated the SwipeToReveal demos, test fixtures, vapor smoke fixture, and the vapor playground to the named slots.

### Checks

- vael-ui 952 tests, vapor-ui 20 tests, docs `vue-tsc`, full build with chunk-split check: all pass.
